### PR TITLE
Use HTTPS for the downloads

### DIFF
--- a/bouncycastle/1.59/Dockerfile
+++ b/bouncycastle/1.59/Dockerfile
@@ -4,13 +4,13 @@ RUN apt update
 RUN apt install -y --no-install-recommends ant git unzip wget strip-nondeterminism file
 
 RUN mkdir -p /opt/junit
-RUN wget http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar -O /opt/junit/junit.jar
+RUN wget https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar -O /opt/junit/junit.jar
 
 RUN mkdir -p /opt/javamail
-RUN wget http://central.maven.org/maven2/javax/mail/javax.mail-api/1.6.1/javax.mail-api-1.6.1.jar -O /opt/javamail/mail.jar
+RUN wget https://repo1.maven.org/maven2/javax/mail/javax.mail-api/1.6.1/javax.mail-api-1.6.1.jar -O /opt/javamail/mail.jar
 
 RUN mkdir -p /opt/jaf
-RUN wget http://central.maven.org/maven2/javax/activation/activation/1.1.1/activation-1.1.1.jar -O /opt/jaf/activation.jar
+RUN wget https://repo1.maven.org/maven2/javax/activation/activation/1.1.1/activation-1.1.1.jar -O /opt/jaf/activation.jar
 
 ADD dependencies_shasums.txt /
 RUN sha256sum --check /dependencies_shasums.txt


### PR DESCRIPTION
All-though not required for integrity as the checksums are being changed it does not hurt and gives privacy as well as protection from having the build failed because someone injects something etc...