### PR TITLE
Add Dockerfile and instructions for PAPYRUS-2.1.0

### DIFF
--- a/rskj/2.1.0-papyrus/Dockerfile
+++ b/rskj/2.1.0-papyrus/Dockerfile
@@ -1,0 +1,23 @@
+# tag name:	openjdk:8-jdk-slim-buster 
+# retrieved:	Thu Sep  3 20:59:42 UTC 2020
+FROM openjdk@sha256:335627a2118556b3f412287e08ac7febb8ecc46325dc6b3570db56f32d33938f
+
+RUN apt-get update -y && \
+    apt-get install -y git curl gnupg && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && \
+    apt-get clean
+
+RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
+RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
+
+RUN git clone --single-branch --depth 1 --branch PAPYRUS-2.1.0 https://github.com/rsksmart/rskj.git /code/rskj
+
+WORKDIR /code/rskj
+
+RUN gpg --verify SHA256SUMS.asc
+RUN sha256sum --check SHA256SUMS.asc
+RUN ./configure.sh
+RUN ./gradlew --no-daemon clean build -x test
+
+RUN sha256sum rskj-core/build/libs/*

--- a/rskj/2.1.0-papyrus/README.md
+++ b/rskj/2.1.0-papyrus/README.md
@@ -1,0 +1,30 @@
+# rskj PAPYRUS-2.1.0
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `PAPYRUS-2.1.0`
+
+## Build
+
+```
+$ docker build -t rskj/papyrus-2.1.0 .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/papyrus-2.1.0 bash -c 'sha256sum /code/rskj/rskj-core/build/libs/rskj-core-2.1.0-PAPYRUS{.jar,-all.jar,-sources.jar,.pom}'
+c9368f17bde640dfcaceb4df78708c23d4fe4bd3945d92d5ebccc8d037d5ddc9  /code/rskj/rskj-core/build/libs/rskj-core-2.1.0-PAPYRUS.jar
+ecc4163c5292cef3b72580f07cfa30dae3996a95fc426ea09766a71e07d58918  /code/rskj/rskj-core/build/libs/rskj-core-2.1.0-PAPYRUS-all.jar
+3e6e0f16dbea9b30057d1fbd8ff60a124f5628a8bdc9ba40714cedad72430c24  /code/rskj/rskj-core/build/libs/rskj-core-2.1.0-PAPYRUS-sources.jar
+b3c6d33856b497532357a2808b41e30c145b686647d926bdad104b7d8eb2e212  /code/rskj/rskj-core/build/libs/rskj-core-2.1.0-PAPYRUS.pom
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/papyrus-2.1.0 /bin/true)
+$ docker cp "$cid":/code/rskj/rskj-core/build/libs/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
This is a bit more disruptive change than usual. To avoid having in the
future with Ubuntu stopping distributing the pinned version of
`openjdk-8-jdk`, instead use an official OpenJDK image as base, and pin
the SHA-256 of that image for the builder.

Additionally, modify the README.md to get all the information in a
single `docker run` and `docker cp`.