### PR TITLE
Iris reproducible build Matching rskj reproducible generation with github actions

### DIFF
--- a/rskj/3.0.0-iris/Dockerfile
+++ b/rskj/3.0.0-iris/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:8-jdk-slim-buster as builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=IRIS-3.0.0 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4 && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test
+
+
+FROM openjdk:8-jre-slim-buster as runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+CMD ["java", "-cp", "rskj-core-3.0.0-IRIS-all.jar", "co.rsk.Start"]

--- a/rskj/3.0.0-iris/README.md
+++ b/rskj/3.0.0-iris/README.md
@@ -1,0 +1,35 @@
+# rskj IRIS-3.0.0
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `IRIS-3.0.0`
+
+## Build
+
+```
+$ docker build -t rskj/3.0.0-iris .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/3.0.0-iris sh -c 'sha256sum *'
+ab8d2e2df0c58535ff437f271c9bb0faf20daabf39c9a06a77b209a56c8a5432  rskj-core-3.0.0-IRIS-all.jar
+6b2cc039bd4fe46f059eb2407012830d7c06519433d7400d8015d154a235e419  rskj-core-3.0.0-IRIS-javadoc.jar
+4aec24fb77222c3a6f9677b9f75e248b0de9b55376774711d77a74d87b80908c  rskj-core-3.0.0-IRIS-sources.jar
+22e14520afd4106a34f1d6bc2826c89f79a0b59ea7575a5c572880e98ef713d3  rskj-core-3.0.0-IRIS.jar
+eb7eea5f696b3bf1a89cfd61a84d9af158e12215500d73810de7a9f5ff86bf77  rskj-core-3.0.0-IRIS.pom
+```
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/3.0.0-iris
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/3.0.0-iris /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
New steps to reproduce automated jar and hash generation with gihub actions in rsksmart/rskj repo.
`https://github.com/rsksmart/rskj/pull/1586`