### PR TITLE
Added reproducible for rskj/6.2.0-arrowhead

### DIFF
--- a/rskj/6.2.0-arrowhead/Dockerfile
+++ b/rskj/6.2.0-arrowhead/Dockerfile
@@ -1,0 +1,31 @@
+FROM openjdk:8-jdk-slim-buster as builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=ARROWHEAD-6.2.0 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM openjdk:8-jre-slim-buster as runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/6.2.0-ARROWHEAD/*.module ./
+CMD ["java", "-cp", "rskj-core-6.2.0-ARROWHEAD-all.jar", "co.rsk.Start"]

--- a/rskj/6.2.0-arrowhead/README.md
+++ b/rskj/6.2.0-arrowhead/README.md
@@ -1,0 +1,35 @@
+# rskj ARROWHEAD-6.2.0
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `ARROWHEAD-6.2.0`
+
+## Build
+
+```
+$ docker build -t rskj/6.2.0-arrowhead .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/6.2.0-arrowhead sh -c 'sha256sum * | grep -v javadoc.jar'
+276e66e411a44f25ce9f4f4b97ada4c5584c7b6d5d6c0871d5e7e6515ec31b43  rskj-core-6.2.0-ARROWHEAD-all.jar
+b8152c66466c12ff41b41603a37279cd88730d1faa642b3544d9290c89d7cc2d  rskj-core-6.2.0-ARROWHEAD-sources.jar
+b2ab2778b1a14bf44b82c82816b4b16fe6dc5e74def66786a5c084a6e0e00fb8  rskj-core-6.2.0-ARROWHEAD.jar
+6eac0bd22ae6e36424d281582bea25369dc7b11156395cebe7ddef70164c1850  rskj-core-6.2.0-ARROWHEAD.module
+d49ed2a57577099471ce8e7c516b9526a85948a3333501a4afba7157b0f803fb  rskj-core-6.2.0-ARROWHEAD.pom
+```
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/6.2.0-arrowhead
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/6.2.0-arrowhead /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
checksums:
```
276e66e411a44f25ce9f4f4b97ada4c5584c7b6d5d6c0871d5e7e6515ec31b43  rskj-core-6.2.0-ARROWHEAD-all.jar
b8152c66466c12ff41b41603a37279cd88730d1faa642b3544d9290c89d7cc2d  rskj-core-6.2.0-ARROWHEAD-sources.jar
b2ab2778b1a14bf44b82c82816b4b16fe6dc5e74def66786a5c084a6e0e00fb8  rskj-core-6.2.0-ARROWHEAD.jar
6eac0bd22ae6e36424d281582bea25369dc7b11156395cebe7ddef70164c1850  rskj-core-6.2.0-ARROWHEAD.module
d49ed2a57577099471ce8e7c516b9526a85948a3333501a4afba7157b0f803fb  rskj-core-6.2.0-ARROWHEAD.pom
```