### PR TITLE
Added reproducible for rskj/6.3.0-arrowhead

### DIFF
--- a/rskj/6.3.0-arrowhead/Dockerfile
+++ b/rskj/6.3.0-arrowhead/Dockerfile
@@ -1,0 +1,31 @@
+FROM openjdk:8-jdk-slim-buster as builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=ARROWHEAD-6.3.0 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM openjdk:8-jre-slim-buster as runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/6.3.0-ARROWHEAD/*.module ./
+CMD ["java", "-cp", "rskj-core-6.3.0-ARROWHEAD-all.jar", "co.rsk.Start"]

--- a/rskj/6.3.0-arrowhead/README.md
+++ b/rskj/6.3.0-arrowhead/README.md
@@ -1,0 +1,35 @@
+# rskj ARROWHEAD-6.3.0
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `ARROWHEAD-6.3.0`
+
+## Build
+
+```
+$ docker build -t rskj/6.3.0-arrowhead .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/6.3.0-arrowhead sh -c 'sha256sum * | grep -v javadoc.jar'
+136ce6e5f55da6346ce716484ff0a49c8f5ef5c00142e124f811bc49e9b25217  rskj-core-6.3.0-ARROWHEAD-all.jar
+0d684f8ed0c9a21af3f0023d3ddbcc06948c0a01b5a21c0d139b1bd4fbb8b2de  rskj-core-6.3.0-ARROWHEAD-sources.jar
+2f74ec8d1c74d9dd20a4c24ee8579a8673d23045cd0b7a32ea4803e638a866d0  rskj-core-6.3.0-ARROWHEAD.jar
+62ffd85fe346ebe4d806251f38b2d24c22324bda894afca50666779b64ddfa84  rskj-core-6.3.0-ARROWHEAD.module
+af87a67835100f049adc0944fdcf8e32a1aab8009b9ceaa82c24d9bef80809c5  rskj-core-6.3.0-ARROWHEAD.pom
+```
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/6.3.0-arrowhead
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/6.3.0-arrowhead /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
checksums:
```
136ce6e5f55da6346ce716484ff0a49c8f5ef5c00142e124f811bc49e9b25217  rskj-core-6.3.0-ARROWHEAD-all.jar
0d684f8ed0c9a21af3f0023d3ddbcc06948c0a01b5a21c0d139b1bd4fbb8b2de  rskj-core-6.3.0-ARROWHEAD-sources.jar
2f74ec8d1c74d9dd20a4c24ee8579a8673d23045cd0b7a32ea4803e638a866d0  rskj-core-6.3.0-ARROWHEAD.jar
62ffd85fe346ebe4d806251f38b2d24c22324bda894afca50666779b64ddfa84  rskj-core-6.3.0-ARROWHEAD.module
af87a67835100f049adc0944fdcf8e32a1aab8009b9ceaa82c24d9bef80809c5  rskj-core-6.3.0-ARROWHEAD.pom
```