### PR TITLE
Added reproducible for rskj/6.3.1-arrowhead

### DIFF
--- a/rskj/6.3.1-arrowhead/Dockerfile
+++ b/rskj/6.3.1-arrowhead/Dockerfile
@@ -1,0 +1,31 @@
+FROM openjdk:8-jdk-slim-buster as builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=ARROWHEAD-6.3.1 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM openjdk:8-jre-slim-buster as runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/6.3.1-ARROWHEAD/*.module ./
+CMD ["java", "-cp", "rskj-core-6.3.1-ARROWHEAD-all.jar", "co.rsk.Start"]

--- a/rskj/6.3.1-arrowhead/README.md
+++ b/rskj/6.3.1-arrowhead/README.md
@@ -1,0 +1,35 @@
+# rskj ARROWHEAD-6.3.1
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `ARROWHEAD-6.3.1`
+
+## Build
+
+```
+$ docker build -t rskj/6.3.1-arrowhead .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/6.3.1-arrowhead sh -c 'sha256sum * | grep -v javadoc.jar'
+27f088e5c7535974203bc77711a1e9bbaa258cd7e5d69cd368d8ca5529b38115  rskj-core-6.3.1-ARROWHEAD-all.jar
+101e35cbaef4c3997432e561417f208f93e5121c52be506bcf2bf22357855bb8  rskj-core-6.3.1-ARROWHEAD-sources.jar
+9e29606d4bd71dd0458ec3eaa61ab4003d6aecad4bf5a5a40cc32d8d6535de75  rskj-core-6.3.1-ARROWHEAD.jar
+bb31e2e2b14f9a15f6c7ca2595a7817860334f38f5d7c6e146306275834b7564  rskj-core-6.3.1-ARROWHEAD.module
+ad539153c8bb8d09307c4a77c9a8af062531241f6a5155c2cd21f0892da27b18  rskj-core-6.3.1-ARROWHEAD.pom
+```
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/6.3.1-arrowhead
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/6.3.1-arrowhead /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
checksums:
```
27f088e5c7535974203bc77711a1e9bbaa258cd7e5d69cd368d8ca5529b38115  rskj-core-6.3.1-ARROWHEAD-all.jar
101e35cbaef4c3997432e561417f208f93e5121c52be506bcf2bf22357855bb8  rskj-core-6.3.1-ARROWHEAD-sources.jar
9e29606d4bd71dd0458ec3eaa61ab4003d6aecad4bf5a5a40cc32d8d6535de75  rskj-core-6.3.1-ARROWHEAD.jar
bb31e2e2b14f9a15f6c7ca2595a7817860334f38f5d7c6e146306275834b7564  rskj-core-6.3.1-ARROWHEAD.module
ad539153c8bb8d09307c4a77c9a8af062531241f6a5155c2cd21f0892da27b18  rskj-core-6.3.1-ARROWHEAD.pom
```