### PR TITLE
Added reproducible for rskj/6.4.0-arrowhead

### DIFF
--- a/rskj/6.4.0-arrowhead/Dockerfile
+++ b/rskj/6.4.0-arrowhead/Dockerfile
@@ -1,0 +1,31 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 as builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=ARROWHEAD-6.4.0 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 as runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/6.4.0-ARROWHEAD/*.module ./
+CMD ["java", "-cp", "rskj-core-6.4.0-ARROWHEAD-all.jar", "co.rsk.Start"]

--- a/rskj/6.4.0-arrowhead/README.md
+++ b/rskj/6.4.0-arrowhead/README.md
@@ -1,0 +1,35 @@
+# rskj ARROWHEAD-6.4.0
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `ARROWHEAD-6.4.0`
+
+## Build
+
+```
+$ docker build -t rskj/6.4.0-arrowhead .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/6.4.0-arrowhead sh -c 'sha256sum * | grep -v javadoc.jar'
+269c6416759ff8979e6bc6a6b1ae96ab95705f1c397df06b160a9f2070a373ce  rskj-core-6.4.0-ARROWHEAD-all.jar
+cb4ecbcf4654d97177389f5505764e3cc9ef5b5f87f7aca2956151c71416d315  rskj-core-6.4.0-ARROWHEAD-sources.jar
+bbc0fc1bb7e865c9e11eb78317db32592c9b7dfd8a6818890729af5827a66237  rskj-core-6.4.0-ARROWHEAD.jar
+fabf8af48c167d42d290e9fa44f80b76b96cd403b56c4c87f8df23fd0ea3c9f0  rskj-core-6.4.0-ARROWHEAD.module
+6dbc8153d510d4e910759e2e76cf40f9c0635185f66aa612dac4b2c8a60d0c63  rskj-core-6.4.0-ARROWHEAD.pom
+```
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/6.4.0-arrowhead
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/6.4.0-arrowhead /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
checksums:

```
269c6416759ff8979e6bc6a6b1ae96ab95705f1c397df06b160a9f2070a373ce  rskj-core-6.4.0-ARROWHEAD-all.jar
cb4ecbcf4654d97177389f5505764e3cc9ef5b5f87f7aca2956151c71416d315  rskj-core-6.4.0-ARROWHEAD-sources.jar
bbc0fc1bb7e865c9e11eb78317db32592c9b7dfd8a6818890729af5827a66237  rskj-core-6.4.0-ARROWHEAD.jar
fabf8af48c167d42d290e9fa44f80b76b96cd403b56c4c87f8df23fd0ea3c9f0  rskj-core-6.4.0-ARROWHEAD.module
6dbc8153d510d4e910759e2e76cf40f9c0635185f66aa612dac4b2c8a60d0c63  rskj-core-6.4.0-ARROWHEAD.pom
```