### PR TITLE
Added reproducible for rskj/6.5.1-arrowhead

### DIFF
--- a/rskj/6.5.1-arrowhead/Dockerfile
+++ b/rskj/6.5.1-arrowhead/Dockerfile
@@ -1,0 +1,31 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 as builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=ARROWHEAD-6.5.1 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 as runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/6.5.1-ARROWHEAD/*.module ./
+CMD ["java", "-cp", "rskj-core-6.5.1-ARROWHEAD-all.jar", "co.rsk.Start"]

--- a/rskj/6.5.1-arrowhead/README.md
+++ b/rskj/6.5.1-arrowhead/README.md
@@ -1,0 +1,34 @@
+# rskj ARROWHEAD-6.5.1
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `ARROWHEAD-6.5.1`
+
+## Build
+
+```
+$ docker build -t rskj/6.5.1-arrowhead .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/6.5.1-arrowhead sh -c 'sha256sum * | grep -v javadoc.jar'
+294f99ec76befa7d9ef18eca28d0c884ceb463ce855ef23ddb7a476e551ba191  rskj-core-6.5.1-ARROWHEAD-all.jar
+ec4ea3143fb95fbf878b24c8d00ebe5994c4586ecf92930743b26dc77395c17a  rskj-core-6.5.1-ARROWHEAD-sources.jar
+16283f4aebbf5b5b35c63f098d81fb0d2aeb5e9fc3be51128ab300333127077f  rskj-core-6.5.1-ARROWHEAD.module
+ee4f7e684044302e3819f8c50d9b85af5b3391d14e6ed6110b98e8387a1b2837  rskj-core-6.5.1-ARROWHEAD.pom
+```
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/6.5.1-arrowhead
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/6.5.1-arrowhead /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
checksums:

```
f4a3407f30f90a1b16b0b5731b98c086548d929a64f36e5f93fdb814ebc2462b  rskj-core-6.5.1-ARROWHEAD-all.jar
5f6a5c354309eda4794380ff007c8711efae1d735a4ab10b7a6e53a8351b9250  rskj-core-6.5.1-ARROWHEAD-sources.jar
8a9a5f36b26158353d0e4cd382246203b04b66d904c07eaaa19b1efeeef0c932  rskj-core-6.5.1-ARROWHEAD.jar
a9fbbe07cdb7fae3f84dc0db7c52c0a94a573cdf8fe9f5dbe7fffe8d1d967bfa  rskj-core-6.5.1-ARROWHEAD.module
ab2e027311d65bb3c5351c29f7f61d2ca16cdecced4db131d489d62941745d84  rskj-core-6.5.1-ARROWHEAD.pom
```