### PR TITLE
Added reproducible for rskj/7.0.0-lovell

### DIFF
--- a/rskj/7.0.0-lovell/Dockerfile
+++ b/rskj/7.0.0-lovell/Dockerfile
@@ -1,0 +1,31 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 as builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=LOVELL-7.0.0 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 as runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/7.0.0-LOVELL/*.module ./
+CMD ["java", "-cp", "rskj-core-7.0.0-LOVELL-all.jar", "co.rsk.Start"]

--- a/rskj/7.0.0-lovell/README.md
+++ b/rskj/7.0.0-lovell/README.md
@@ -1,0 +1,35 @@
+# rskj ARROWHEAD-6.5.1
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `LOVELL-7.0.0`
+
+## Build
+
+```
+$ docker build -t rskj/7.0.0-lovell .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/7.0.0-lovell sh -c 'sha256sum * | grep -v javadoc.jar'
+604b75665d9750da216ddc9849cb2276a06192321b3c6829685600e1f2d534fb  rskj-core-7.0.0-LOVELL-all.jar
+05fb616708088a6c65326c01d7e79b2c332d5f2ca83246c9075f65e5fa2781fe  rskj-core-7.0.0-LOVELL-sources.jar
+8d131bbc8d1d346ec4a91ce4eb9db59f6c7649bb7698b11bc1abbaf33f75caaa  rskj-core-7.0.0-LOVELL.jar
+e85d0783b39ef93fda5f98588f7e4ae5d57784096ce9b3a1f43eb3d99a49d275  rskj-core-7.0.0-LOVELL.module
+d651adc77b82046a976bf5c7e858b741443bc8ffa8372b8e5bac9b92dc8c294d  rskj-core-7.0.0-LOVELL.pom
+```
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/7.0.0-lovell
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/7.0.0-lovell /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```

--- a/rskj/7.0.0-lovell/README.md
+++ b/rskj/7.0.0-lovell/README.md
@@ -1,4 +1,4 @@
-# rskj ARROWHEAD-6.5.1
+# rskj LOVELL-7.0.0
 
 * Source: https://github.com/rsksmart/rskj
 * Tag: `LOVELL-7.0.0`


### PR DESCRIPTION
checksums:

```
604b75665d9750da216ddc9849cb2276a06192321b3c6829685600e1f2d534fb  rskj-core-7.0.0-LOVELL-all.jar
05fb616708088a6c65326c01d7e79b2c332d5f2ca83246c9075f65e5fa2781fe  rskj-core-7.0.0-LOVELL-sources.jar
8d131bbc8d1d346ec4a91ce4eb9db59f6c7649bb7698b11bc1abbaf33f75caaa  rskj-core-7.0.0-LOVELL.jar
e85d0783b39ef93fda5f98588f7e4ae5d57784096ce9b3a1f43eb3d99a49d275  rskj-core-7.0.0-LOVELL.module
d651adc77b82046a976bf5c7e858b741443bc8ffa8372b8e5bac9b92dc8c294d  rskj-core-7.0.0-LOVELL.pom
```