### PR TITLE
Add CD to bitcoinj-thin

### DIFF
--- a/.github/workflows/bitcoinj-cd.yml
+++ b/.github/workflows/bitcoinj-cd.yml
@@ -1,0 +1,57 @@
+## Copyright (c) 2025 Rootstock Labs
+## Copyright (c) 2025 Andres Tarrio <andres.tarrio@rootstocklabs.com>
+## Perform a reproducible build of BitcoinJ Thin and upload the resulting 
+## JAR and pom files to an S3 bucket, along with the md5sums list for the build
+
+name: Build and Upload BitcoinJ Thin
+
+on:
+  push:
+    tags:
+      - 'bitcoinj-thin-*'
+
+jobs:
+  ## build the image and upload it to S3
+  build_and_upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment: bitcoinj-thin-cd
+    steps:
+    - name: Set version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/bitcoinj-thin-}" >> $GITHUB_ENV
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build Docker image
+      run: |
+        docker build --no-cache -t bitcoinj-thin:${VERSION} bitcoinj-thin/${VERSION} 
+
+    - name: Run container and extract files
+      run: |
+        docker run --name bitcoinj-thin-container -d bitcoinj-thin:${VERSION} /bin/true
+        docker cp bitcoinj-thin-container:/home/bitcoinj-thin/${{ github.ref_name }}.jar ./${{ github.ref_name }}.jar
+        docker cp bitcoinj-thin-container:/home/bitcoinj-thin/pom.xml ./${{ github.ref_name }}.xml
+
+    - name: Set up AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        aws-region: us-east-1
+
+    - name: Upload to S3 bucket
+      run: |
+        aws s3 sync . s3://rsk-repository/co/rsk/bitcoinj/bitcoinj-thin/${VERSION} \
+          --exclude "*" \
+          --include "${{ github.ref_name }}.jar" \
+          --include "${{ github.ref_name }}.xml" \
+
+    - name: Stop and remove container
+      run: |
+        docker stop bitcoinj-thin-container
+        docker rm bitcoinj-thin-container

--- a/bitcoinj-thin/example_dockerfile/Dockerfile
+++ b/bitcoinj-thin/example_dockerfile/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:20.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+## For ARM64 (Mac Silicon) you might want to change this to /usr/lib/jvm/java-8-openjdk-arm64/
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends openjdk-8-jdk file unzip git strip-nondeterminism && \
+    apt-get install -qq --no-install-recommends maven
+
+WORKDIR /code/bitcoinj-thin
+
+RUN gitrev=v0.14.4-rsk-19 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/bitcoinj-thin.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN mvn clean package -DskipTests
+RUN strip-nondeterminism ./target/bitcoinj-thin-*
+
+FROM ubuntu:20.04 AS runner
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends openjdk-8-jre 
+
+
+RUN useradd -m rsk
+
+WORKDIR /home/bitcoinj-thin
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/bitcoinj-thin/* ./

--- a/bitcoinj-thin/example_dockerfile/README.md
+++ b/bitcoinj-thin/example_dockerfile/README.md
@@ -1,0 +1,9 @@
+# New Dockerfile format
+This folder contains a Dockerfile for building a bitcoinj-thin inside a docker container.
+The old openjdk base image was deprecated, so this Dockerfile uses a base ubuntu image instead and just installs 
+java 8 on it. The old base image was based on debian buster, so it wouldn't let you install any packages. Newer openjdk images
+don't have java 8 variants, so we use the ubuntu image instead.
+
+# Continuous Deployment
+A github action has been added to automatically build the image and push the extracted files to the rsk-repository bucket on S3.
+For this to work, you need to create and push a tag in the format `bitcoinj-thin-<version>`, where `<version>` is the version of bitcoinj-thin you want to build. Don't forget of course to include the proper bitcoinj-thin/<version> directory with the corresponding Dockerfile.


### PR DESCRIPTION
Added GitHub action to build and publish the bitcoinj-thin files. Also, the Dockerfile used was based on a deprecated version of debian, so I updated it to use ubuntu with java 8. Please note that this is a workaround to make things work for now, but we should be looking at making bitcoinj-thin buildable with more recent versions of java.