### PR TITLE
Adding reproducible build for Reed-8.1.0

### DIFF
--- a/rskj/8.1.0-reed/Dockerfile
+++ b/rskj/8.1.0-reed/Dockerfile
@@ -1,0 +1,31 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 as builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=REED-8.1.0 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 as runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/8.1.0-REED/*.module ./
+CMD ["java", "-cp", "rskj-core-8.1.0-REED-all.jar", "co.rsk.Start"]

--- a/rskj/8.1.0-reed/Dockerfile
+++ b/rskj/8.1.0-reed/Dockerfile
@@ -27,5 +27,7 @@ WORKDIR /home/rsk
 
 USER rsk
 COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/rskj-core-*.pom ./
 COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/8.1.0-REED/*.module ./
+
 CMD ["java", "-cp", "rskj-core-8.1.0-REED-all.jar", "co.rsk.Start"]

--- a/rskj/8.1.0-reed/README.md
+++ b/rskj/8.1.0-reed/README.md
@@ -15,10 +15,11 @@ The last step of the build prints the sha256sum of the files, if, for any reason
 
 ```
 $ docker run --rm rskj/8.1.0-reed sh -c 'sha256sum * | grep -v javadoc.jar'
-f8535514f7a02181da768543782ec9b811128b6af20f44d1d5c0c5510ecdaaf1  rskj-core-8.1.0-REED-all.jar                                                                                                        ─╯
+f8535514f7a02181da768543782ec9b811128b6af20f44d1d5c0c5510ecdaaf1  rskj-core-8.1.0-REED-all.jar
 e4eaa4d19b0fc35f637b2db5726d3168326b0585cd4bfa87c8e806b4acececad  rskj-core-8.1.0-REED-sources.jar
 9881cd4c2d50967d62a0c73bb2cd5ee2bda54917e162be6feb9e5e63159ba4a8  rskj-core-8.1.0-REED.jar
 ad13579e87e63dbf356fb3da20a468c6155e12be60633d13671f1d2005b645bd  rskj-core-8.1.0-REED.module
+33776365d7b1eb230aaf644b54992a8e3bb49d46ba3f54c8455fcaabdad42c76  rskj-core-8.1.0-REED.pom
 ```
 
 ## (Optional) Run RSK Node

--- a/rskj/8.1.0-reed/README.md
+++ b/rskj/8.1.0-reed/README.md
@@ -1,0 +1,35 @@
+# rskj REED-8.1.0
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `REED-8.1.0`
+
+## Build
+
+```
+$ docker build -t rskj/8.1.0-reed .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/8.1.0-reed sh -c 'sha256sum * | grep -v javadoc.jar'
+f8535514f7a02181da768543782ec9b811128b6af20f44d1d5c0c5510ecdaaf1  rskj-core-8.1.0-REED-all.jar                                                                                                        ─╯
+e4eaa4d19b0fc35f637b2db5726d3168326b0585cd4bfa87c8e806b4acececad  rskj-core-8.1.0-REED-sources.jar
+9881cd4c2d50967d62a0c73bb2cd5ee2bda54917e162be6feb9e5e63159ba4a8  rskj-core-8.1.0-REED.jar
+ad13579e87e63dbf356fb3da20a468c6155e12be60633d13671f1d2005b645bd  rskj-core-8.1.0-REED.module
+```
+
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/8.1.0-reed
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/8.1.0-reed /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
The reproducible build:

```
f8535514f7a02181da768543782ec9b811128b6af20f44d1d5c0c5510ecdaaf1  rskj-core-8.1.0-REED-all.jar
e4eaa4d19b0fc35f637b2db5726d3168326b0585cd4bfa87c8e806b4acececad  rskj-core-8.1.0-REED-sources.jar
9881cd4c2d50967d62a0c73bb2cd5ee2bda54917e162be6feb9e5e63159ba4a8  rskj-core-8.1.0-REED.jar
ad13579e87e63dbf356fb3da20a468c6155e12be60633d13671f1d2005b645bd  rskj-core-8.1.0-REED.module
33776365d7b1eb230aaf644b54992a8e3bb49d46ba3f54c8455fcaabdad42c76  rskj-core-8.1.0-REED.pom
```