### PR TITLE
Add reproducible build for rskj VETIVER-9.0.0

### DIFF
--- a/rskj/9.0.0-vetiver/Dockerfile
+++ b/rskj/9.0.0-vetiver/Dockerfile
@@ -15,7 +15,7 @@ RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991
     gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
     sha256sum --check SHA256SUMS && \
     ./configure.sh && \
-    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew --no-daemon clean build -x test -x checkstyleMain -x checkstyleTest -x checkstyleIntegrationTest && \
     ./gradlew publishRskjPublicationToMavenLocal
 
 

--- a/rskj/9.0.0-vetiver/Dockerfile
+++ b/rskj/9.0.0-vetiver/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=VETIVER-9.0.0 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 AS runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/rskj-core-*.pom ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/9.0.0-VETIVER/*.module ./
+
+CMD ["java", "-cp", "rskj-core-9.0.0-VETIVER-all.jar", "co.rsk.Start"]

--- a/rskj/9.0.0-vetiver/README.md
+++ b/rskj/9.0.0-vetiver/README.md
@@ -1,0 +1,32 @@
+# rskj VETIVER-9.0.0
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `VETIVER-9.0.0`
+
+## Build
+
+```
+$ docker build -t rskj/9.0.0-vetiver .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/9.0.0-vetiver sh -c 'sha256sum * | grep -v javadoc.jar'
+<TODO ADD SHA256SUM>
+```
+
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/9.0.0-vetiver
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/9.0.0-vetiver /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```

--- a/rskj/9.0.0-vetiver/README.md
+++ b/rskj/9.0.0-vetiver/README.md
@@ -15,7 +15,11 @@ The last step of the build prints the sha256sum of the files, if, for any reason
 
 ```
 $ docker run --rm rskj/9.0.0-vetiver sh -c 'sha256sum * | grep -v javadoc.jar'
-<TODO ADD SHA256SUM>
+f120a63d685a4df9344371358ac16bbd65ed54b09db79357d2f1fdc2c94c8a8f  rskj-core-9.0.0-VETIVER-all.jar
+035decfbcd1dfcb1cf90290e14d95cc621abe2482375802453f13ee458730526  rskj-core-9.0.0-VETIVER-sources.jar
+04bb7ca2016e9e66b2924222c67e6bef0d7f41f24c08d23fe5edf0615bbb430b  rskj-core-9.0.0-VETIVER.jar
+c09bebc2d210fcfa19c32ce110fe93a892bf4f3391f704165f0eec5cbadf26b6  rskj-core-9.0.0-VETIVER.module
+2b92ef7957248997ebe4b7581aa5a923414c31e65cd729fed64d7c8cf24a99ed  rskj-core-9.0.0-VETIVER.pom
 ```
 
 ## (Optional) Run RSK Node


### PR DESCRIPTION
Values to check below:

```
f120a63d685a4df9344371358ac16bbd65ed54b09db79357d2f1fdc2c94c8a8f  rskj-core-9.0.0-VETIVER-all.jar
035decfbcd1dfcb1cf90290e14d95cc621abe2482375802453f13ee458730526  rskj-core-9.0.0-VETIVER-sources.jar
04bb7ca2016e9e66b2924222c67e6bef0d7f41f24c08d23fe5edf0615bbb430b  rskj-core-9.0.0-VETIVER.jar
c09bebc2d210fcfa19c32ce110fe93a892bf4f3391f704165f0eec5cbadf26b6  rskj-core-9.0.0-VETIVER.module
2b92ef7957248997ebe4b7581aa5a923414c31e65cd729fed64d7c8cf24a99ed  rskj-core-9.0.0-VETIVER.pom
```