### PR TITLE
Add reproducible build for VETIVER-9.0.1

### DIFF
--- a/rskj/9.0.1-vetiver/Dockerfile
+++ b/rskj/9.0.1-vetiver/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=VETIVER-9.0.1 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test -x checkstyleMain -x checkstyleTest -x checkstyleIntegrationTest && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 AS runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/rskj-core-*.pom ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/9.0.1-VETIVER/*.module ./
+
+CMD ["java", "-cp", "rskj-core-9.0.1-VETIVER-all.jar", "co.rsk.Start"]

--- a/rskj/9.0.1-vetiver/README.md
+++ b/rskj/9.0.1-vetiver/README.md
@@ -1,0 +1,36 @@
+# rskj VETIVER-9.0.1
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `VETIVER-9.0.1`
+
+## Build
+
+```
+$ docker build -t rskj/9.0.1-vetiver .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/9.0.1-vetiver sh -c 'sha256sum * | grep -v javadoc.jar'
+ffa9ada4e58ede93b342171ce635392f99315b744efbf251bda2fb2cd18da3bb  rskj-core-9.0.1-VETIVER-all.jar
+d21a454cf8b16624db23cc4de210840567f3980685046602f9cb44b79085bb49  rskj-core-9.0.1-VETIVER-sources.jar
+cc80674ba45588f56bd67a7661f577842cd55661cef89a05b6baa99180381171  rskj-core-9.0.1-VETIVER.jar
+d2f76bc758ea000cbb9259bd19854bcf4e498004bf68a8aad51f8c6c3839593a  rskj-core-9.0.1-VETIVER.module
+481b7d6aca96ec2c4c281e8e9558a8df6bd47e3ffab443399ee4b0d7bb1873b5  rskj-core-9.0.1-VETIVER.pom
+```
+
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/9.0.1-vetiver
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/9.0.1-vetiver /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
Hashes to verify:

```
ffa9ada4e58ede93b342171ce635392f99315b744efbf251bda2fb2cd18da3bb  rskj-core-9.0.1-VETIVER-all.jar
d21a454cf8b16624db23cc4de210840567f3980685046602f9cb44b79085bb49  rskj-core-9.0.1-VETIVER-sources.jar
cc80674ba45588f56bd67a7661f577842cd55661cef89a05b6baa99180381171  rskj-core-9.0.1-VETIVER.jar
d2f76bc758ea000cbb9259bd19854bcf4e498004bf68a8aad51f8c6c3839593a  rskj-core-9.0.1-VETIVER.module
481b7d6aca96ec2c4c281e8e9558a8df6bd47e3ffab443399ee4b0d7bb1873b5  rskj-core-9.0.1-VETIVER.pom
```