### PR TITLE
Add reproducible build for rskj VETIVER-9.0.2

### DIFF
--- a/rskj/9.0.2-vetiver/Dockerfile
+++ b/rskj/9.0.2-vetiver/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS builder
+
+RUN apt-get update -y && \
+    apt-get install -qq --no-install-recommends git curl gnupg
+
+WORKDIR /code/rskj
+
+RUN gitrev=VETIVER-9.0.2 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test -x checkstyleMain -x checkstyleTest -x checkstyleIntegrationTest && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 AS runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/rskj-core-*.pom ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/9.0.2-VETIVER/*.module ./
+
+CMD ["java", "-cp", "rskj-core-9.0.2-VETIVER-all.jar", "co.rsk.Start"]

--- a/rskj/9.0.2-vetiver/Dockerfile
+++ b/rskj/9.0.2-vetiver/Dockerfile
@@ -1,7 +1,8 @@
 FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS builder
 
 RUN apt-get update -y && \
-    apt-get install -qq --no-install-recommends git curl gnupg
+    apt-get install -y -qq --no-install-recommends git curl gnupg && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code/rskj
 

--- a/rskj/9.0.2-vetiver/README.md
+++ b/rskj/9.0.2-vetiver/README.md
@@ -1,0 +1,36 @@
+# rskj VETIVER-9.0.2
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `VETIVER-9.0.2`
+
+## Build
+
+```
+$ docker build -t rskj/9.0.2-vetiver .
+```
+
+## Verify
+
+The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+
+```
+$ docker run --rm rskj/9.0.2-vetiver sh -c 'sha256sum * | grep -v javadoc.jar'
+9a46e412812bb6661f8af74fa77f3fb089ba4cd9695951789a3b89d6f90b777e  rskj-core-9.0.2-VETIVER-all.jar
+0749f277eb7a9dfa7707b2a3a91342176daf311dc5f6ed2435e845844795f178  rskj-core-9.0.2-VETIVER-sources.jar
+e07b5da8832ea5dce2a71a79b7eec2e4627d1ef27b7031dc27297805ce56de21  rskj-core-9.0.2-VETIVER.jar
+b9db56e6d5a3cf74d040c567566d227048ff3f04df84741c6641e86a91ca2e73  rskj-core-9.0.2-VETIVER.module
+a6d2b797ff8f114c44d90a565c25384ab8737b2ea8d373a1b6644f04d9e5f2a7  rskj-core-9.0.2-VETIVER.pom
+```
+
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/9.0.2-vetiver
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/9.0.2-vetiver /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```

--- a/rskj/9.0.2-vetiver/README.md
+++ b/rskj/9.0.2-vetiver/README.md
@@ -11,7 +11,7 @@ $ docker build -t rskj/9.0.2-vetiver .
 
 ## Verify
 
-The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+Run the following command to verify the sha256sum of the built artifacts matches the expected values:
 
 ```
 $ docker run --rm rskj/9.0.2-vetiver sh -c 'sha256sum * | grep -v javadoc.jar'


### PR DESCRIPTION
Hashes:

```
9a46e412812bb6661f8af74fa77f3fb089ba4cd9695951789a3b89d6f90b777e  rskj-core-9.0.2-VETIVER-all.jar
0749f277eb7a9dfa7707b2a3a91342176daf311dc5f6ed2435e845844795f178  rskj-core-9.0.2-VETIVER-sources.jar
e07b5da8832ea5dce2a71a79b7eec2e4627d1ef27b7031dc27297805ce56de21  rskj-core-9.0.2-VETIVER.jar
b9db56e6d5a3cf74d040c567566d227048ff3f04df84741c6641e86a91ca2e73  rskj-core-9.0.2-VETIVER.module
a6d2b797ff8f114c44d90a565c25384ab8737b2ea8d373a1b6644f04d9e5f2a7  rskj-core-9.0.2-VETIVER.pom
```