### PR TITLE
Add rskj reproducible build for VETIVER-9.0.1

### DIFF
--- a/rskj/9.0.1-vetiver/Dockerfile
+++ b/rskj/9.0.1-vetiver/Dockerfile
@@ -1,7 +1,8 @@
 FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS builder
 
 RUN apt-get update -y && \
-    apt-get install -qq --no-install-recommends git curl gnupg
+    apt-get install -y -qq --no-install-recommends git curl gnupg && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code/rskj
 

--- a/rskj/9.0.1-vetiver/README.md
+++ b/rskj/9.0.1-vetiver/README.md
@@ -11,7 +11,7 @@ $ docker build -t rskj/9.0.1-vetiver .
 
 ## Verify
 
-The last step of the build prints the sha256sum of the files, if, for any reason there's a need to recheck the hash the following commands can be used to generate them.
+Run the following command to verify the sha256sum of the built artifacts matches the expected values:
 
 ```
 $ docker run --rm rskj/9.0.1-vetiver sh -c 'sha256sum * | grep -v javadoc.jar'


### PR DESCRIPTION
rskj reproducible build for version 9.0.1

```
ffa9ada4e58ede93b342171ce635392f99315b744efbf251bda2fb2cd18da3bb  rskj-core-9.0.1-VETIVER-all.jar
d21a454cf8b16624db23cc4de210840567f3980685046602f9cb44b79085bb49  rskj-core-9.0.1-VETIVER-sources.jar
cc80674ba45588f56bd67a7661f577842cd55661cef89a05b6baa99180381171  rskj-core-9.0.1-VETIVER.jar
d2f76bc758ea000cbb9259bd19854bcf4e498004bf68a8aad51f8c6c3839593a  rskj-core-9.0.1-VETIVER.module
481b7d6aca96ec2c4c281e8e9558a8df6bd47e3ffab443399ee4b0d7bb1873b5  rskj-core-9.0.1-VETIVER.pom
```
