### PR TITLE
Reproducible generation script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,15 +39,15 @@ nothing is hardcoded, so it won't drift as conventions change.
 
 The PR body is filled in with a brief description and the artifact hashes:
 
-```
+~~~~
 <component> reproducible build for version <version>
 
-​```
+~~~
 <sha256>  <artifact-1>
 <sha256>  <artifact-2>
 ...
-​```
-```
+~~~
+~~~~
 
 ### Requirements
 
@@ -141,8 +141,7 @@ existing build and commit the change.
 - The branch is created from `<remote>/<base>` after fetching (and before any files are
   written into the repo), so it doesn't depend on — or collide with — your local state.
 - If `gh` isn't installed, the script prints the PR title and a compare URL to open manually.
-- Verifying an existing/published release (the inverse of this) is a separate, standalone
-  tool: `verify-release.js`.
+- Verifying a reproducible-build PR is handled by the `validate` mode of `generate-build.js` (see below).
 
 ## Validating a PR (`validate`)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,166 @@
+# scripts
+
+Tooling for maintaining this repository.
+
+## generate-build.js
+
+Generates a reproducible-build entry for a release tag end to end: it scaffolds the folder,
+builds it, verifies the result against the published GitHub release, then commits and pushes
+a branch and opens a PR.
+
+It uses the **newest existing folder of the same project as the template**, so a new build
+automatically inherits the current base images, GPG key, gradle flags, and README wording —
+nothing is hardcoded, so it won't drift as conventions change.
+
+### What it does
+
+1. Parses the tag and picks the component (`rskj` vs `powpeg-node`) from the version shape
+   (3 parts → rskj, 4 parts → powpeg-node; override with `--component`).
+2. **Verifies the git tag exists** in the source repo (fail fast before the long build). The
+   tag — not a GitHub release — is the reference, because the release is published *after* the
+   reproducible build is accepted. Source integrity is then enforced inside the build itself
+   (the Dockerfile GPG-verifies `SHA256SUMS` for the checked-out source).
+3. Copies the newest existing folder of that project and substitutes the version everywhere
+   it appears, producing the new `Dockerfile`.
+4. Runs `docker build`, then `sha256sum *` inside the image to get the artifact hashes.
+5. *(Informational only)* If a GitHub release already exists for the tag, notes whether the
+   fat jar matches it. Usually there's no release yet, so this is skipped — it's never a gate.
+6. Writes `README.md` with the computed hashes.
+7. Creates a branch (`repro/<component>-<folder>`), commits **only the new folder**, pushes
+   to the detected remote, and opens a PR with `gh` (or prints the PR title + compare URL).
+
+The PR body is filled in with a brief description and the artifact hashes:
+
+```
+<component> reproducible build for version <version>
+
+​```
+<sha256>  <artifact-1>
+<sha256>  <artifact-2>
+...
+​```
+```
+
+### Requirements
+
+- Node.js ≥ 18 (uses the built-in `fetch`)
+- Docker (the build runs on every invocation to compute real hashes)
+- git, with this repo checked out and a remote you can push to
+- Optional: [`gh`](https://cli.github.com/) (GitHub CLI) to open the PR automatically
+
+### Usage
+
+Run it from anywhere inside the repo — it finds the repo root itself:
+
+```bash
+node scripts/generate-build.js <tag> [options]
+```
+
+Examples:
+
+```bash
+# rskj (3-part version, auto-detected)
+node scripts/generate-build.js VETIVER-9.0.3
+
+# powpeg-node (4-part version, auto-detected)
+node scripts/generate-build.js VETIVER-9.0.1.0
+
+# build + verify + write files, but make NO git changes (recommended first run)
+node scripts/generate-build.js VETIVER-9.0.3 --dry-run
+
+# create the branch + commit but don't push
+node scripts/generate-build.js VETIVER-9.0.3 --no-push
+```
+
+#### Testing the process against an already-accepted build
+
+To exercise the tool against a tag whose build folder already exists on `master` (instead of
+inventing a fake tag), use `--allow-existing`. The folder already lives on `master`, so the
+already-exists guard would normally stop you. `--allow-existing` lets it proceed — and because
+a faithful build reproduces the committed files byte-for-byte, it ends with **"nothing to
+commit"**, which is itself proof that the build reproduces:
+
+```bash
+# full run against an existing build — confirms it reproduces, makes no commit
+node scripts/generate-build.js VETIVER-9.0.1 --allow-existing
+
+# or just build + verify the hashes, touch nothing in git
+node scripts/generate-build.js VETIVER-9.0.1 --dry-run
+```
+
+Use `--force` (not `--allow-existing`) only when you actually intend to **overwrite** an
+existing build and commit the change.
+
+### Options
+
+| Option | Description |
+| --- | --- |
+| `-c, --component <c>` | `rskj` or `powpeg-node` (default: auto-detected from the version). |
+| `-b, --branch <name>` | Branch to create (default: `repro/<component>-<folder>`). |
+| `--remote <name>` | Git remote to push to (default: auto-detected, prefers `origin`). |
+| `--base <branch>` | Base branch (default: `master`). |
+| `--no-push` | Create the branch + commit but don't push. |
+| `--dry-run` | Build and write files, but make no git changes (also skips the already-exists check). |
+| `--allow-existing` | Regenerate a build that already exists (for testing). |
+| `--keep-image` | Keep the Docker image after building. |
+| `--force` | Proceed despite a dirty tree, an existing folder, or a missing source tag. |
+| `-h, --help` | Show help. |
+
+### Environment (all optional)
+
+- `GITHUB_TOKEN` (or `GH_TOKEN`) — raises GitHub API rate limits for the release cross-check.
+- `REPRO_REMOTE` / `REPRO_BASE_BRANCH` — override the push remote / base branch.
+- `NO_COLOR` — disable colored output.
+
+### Safety behavior
+
+- Refuses to run on a **dirty working tree** (tracked changes) — commit or stash first, or
+  pass `--force`.
+- Refuses if the **target folder already exists** — checked both on disk **and on
+  `<remote>/<base>`**, so an already-published build is caught even when your local checkout
+  is behind. Use `--force` to overwrite.
+- **Verifies the source tag exists** before building (fail fast). A GitHub release is *not*
+  required and never gates the build — it's published after the reproducible build is
+  accepted. If a release happens to exist already, a hash comparison is shown for information
+  only.
+- The Docker build runs in a **temporary directory**, so a failed build never leaves
+  untracked files in the repo, and the branch is created off a clean tree.
+- Commits **only** the new build folder, never the script or other changes. If the generated
+  files are identical to what's already on the base branch, it stops without an empty commit.
+
+### Notes
+
+- The branch is created from `<remote>/<base>` after fetching (and before any files are
+  written into the repo), so it doesn't depend on — or collide with — your local state.
+- If `gh` isn't installed, the script prints the PR title and a compare URL to open manually.
+- Verifying an existing/published release (the inverse of this) is a separate, standalone
+  tool: `verify-release.js`.
+
+## Validating a PR (`validate`)
+
+Reproduces the build proposed in a pull request and posts the result as a PR comment — handy
+for reviewing reproducible-build PRs.
+
+```bash
+node scripts/generate-build.js validate https://github.com/rsksmart/reproducible-builds/pull/123
+```
+
+It reads the PR's changed files to find the build folder, fetches that folder's `Dockerfile`
+and `README.md` from the **PR's head branch**, rebuilds it with Docker, and compares the
+freshly computed hashes against the sha256 block in the committed **`README.md` file**. The
+PR description text is not used for validation — it's purely cosmetic. Then it comments:
+
+- **match** → `Hashes verified!` followed by the artifact list;
+- **mismatch** → `Hashes differ!!` followed by the artifact list (and the console prints a
+  per-file diff).
+
+Exit code is `0` on match, `1` on mismatch — so it's CI-friendly.
+
+```bash
+# preview the comment without posting it
+node scripts/generate-build.js validate <pr-url> --dry-run
+```
+
+Posting the comment uses `gh` if installed, otherwise the GitHub API with `GITHUB_TOKEN`; if
+neither is available it prints the comment for you to paste. Validation works on PRs from
+forks too (it builds from the PR head repo). It needs Docker, but not a local clone or git.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,14 @@
 
 Tooling for maintaining this repository.
 
+| File | Purpose |
+| --- | --- |
+| `generate-build.js` | CLI: the `generate` and `validate` commands, plus all I/O (git, Docker, GitHub). |
+| `lib.js` | Pure, side-effect-free logic (component conventions, tag parsing, version substitution, sha-block handling). |
+| `lib.test.js` | Unit tests for `lib.js`. Run from this folder: `node --test lib.test.js`. |
+
+All zero-dependency — just Node. There's no build step and nothing to install.
+
 ## generate-build.js
 
 Generates a reproducible-build entry for a release tag end to end: it scaffolds the folder,

--- a/scripts/generate-build.js
+++ b/scripts/generate-build.js
@@ -425,11 +425,15 @@ function openPr({ repoDir, remote, base, branch, component, tag, version, shaBlo
   const title = `Add ${component.name} reproducible build for ${tag}`;
   const body = `${component.name} reproducible build for version ${version}\n\n${hashFence(shaBlock)}\n`;
 
+  const slug = githubSlug(repoDir, remote);
+  const owner = slug ? slug.split('/')[0] : null;
+  const head = owner && owner !== UPSTREAM.split('/')[0] ? `${owner}:${branch}` : branch;
+
   if (has('gh')) {
     step('Opening a PR with gh');
     const r = spawnSync(
       'gh',
-      ['pr', 'create', '--repo', UPSTREAM, '--base', base, '--head', branch, '--title', title, '--body', body],
+      ['pr', 'create', '--repo', UPSTREAM, '--base', base, '--head', head, '--title', title, '--body', body],
       { cwd: repoDir, stdio: 'inherit' },
     );
     if (!r.error && r.status === 0) return;
@@ -437,13 +441,10 @@ function openPr({ repoDir, remote, base, branch, component, tag, version, shaBlo
   } else {
     step('PR info (gh not found — copy/paste to open the PR)');
   }
-  const slug = githubSlug(repoDir, remote);
-  const owner = slug ? slug.split('/')[0] : null;
-  const head = owner && owner !== UPSTREAM.split('/')[0] ? `${owner}:${branch}` : branch;
   const q = `expand=1&title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
   console.log(`  title: ${title}`);
   console.log(`  body:\n${body.split('\n').map((l) => '    ' + l).join('\n')}`);
-  console.log(`  url:   https://github.com/${UPSTREAM}/compare/${base}...${encodeURIComponent(head)}?${q}`);
+  console.log(`  url:   https://github.com/${UPSTREAM}/compare/${base}...${encodeURI(head)}?${q}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -497,11 +498,17 @@ async function modeValidate(prUrl, opts) {
   const headRef = meta.head && meta.head.ref;
   if (!headRef) die('could not determine the PR head ref.', 1);
 
-  const files = await ghJson(`https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}/files?per_page=100`);
+  let files = [];
+  for (let page = 1; ; page++) {
+    const pageFiles = await ghJson(
+      `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}/files?per_page=100&page=${page}`,
+    );
+    files = files.concat(pageFiles);
+    if (pageFiles.length < 100) break;
+  }
   let build;
   try {
     build = detectBuildFromFiles(files.map((f) => f.filename));
-  } catch (e) {
     die(e.message, 1); // e.g. PR touches multiple build folders
   }
   if (!build) die('this PR does not add a recognized rskj/ or powpeg-node/ build folder.', 1);
@@ -509,7 +516,7 @@ async function modeValidate(prUrl, opts) {
   console.log(c.dim(`  build: ${component.subdir}/${folder}   (head ${headRepo}@${headRef})`));
 
   // 2. Fetch the PR's Dockerfile + README from the head ref.
-  const rawBase = `https://raw.githubusercontent.com/${headRepo}/${encodeURIComponent(headRef)}/${component.subdir}/${folder}`;
+  const rawBase = `https://raw.githubusercontent.com/${headRepo}/${encodeURI(headRef)}/${component.subdir}/${folder}`;
   step('Fetching the build files from the PR');
   const dockerfile = await fetchTextOrDie(`${rawBase}/Dockerfile`, 'Dockerfile');
   const prReadme = await fetchTextOrDie(`${rawBase}/README.md`, 'README.md');

--- a/scripts/generate-build.js
+++ b/scripts/generate-build.js
@@ -509,6 +509,7 @@ async function modeValidate(prUrl, opts) {
   let build;
   try {
     build = detectBuildFromFiles(files.map((f) => f.filename));
+  } catch (e) {
     die(e.message, 1); // e.g. PR touches multiple build folders
   }
   if (!build) die('this PR does not add a recognized rskj/ or powpeg-node/ build folder.', 1);

--- a/scripts/generate-build.js
+++ b/scripts/generate-build.js
@@ -1,0 +1,702 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Reproducible-build generator.
+ *
+ * Given a release tag, this scaffolds a new reproducible-build folder for rskj
+ * or powpeg-node by cloning the *newest existing* folder of that project as a
+ * template (so it always inherits the latest base images, gpg keys, gradle
+ * flags, etc.), then:
+ *
+ *   1. verifies the source git TAG exists (the release is published later, so
+ *      the tag — not a release — is the reference here),
+ *   2. renders the Dockerfile for the new tag,
+ *   3. builds it with Docker and captures the artifact sha256sums (source
+ *      integrity is enforced in-build via the Dockerfile's GPG SHA256SUMS check),
+ *   4. writes the README with the real hashes,
+ *   5. creates a branch, commits, and pushes it,
+ *   6. opens a PR with `gh` if available, otherwise prints the PR info.
+ *
+ * If a GitHub release already happens to exist for the tag, a hash comparison
+ * is shown for information only — it never gates the build.
+ *
+ * This script is meant to live inside the reproducible-builds repo: it finds
+ * its own repo root via git and operates on it — no config/paths needed.
+ *
+ * Usage:
+ *   node generate-build.js <tag> [options]
+ *
+ *   <tag>   e.g. VETIVER-9.0.3 (rskj) or VETIVER-9.0.1.0 (powpeg-node)
+ *
+ * Options:
+ *   -c, --component <c>  rskj | powpeg-node  (default: auto from version shape)
+ *   -b, --branch <name>  branch to create    (default: repro/<component>-<folder>)
+ *       --remote <name>  git remote to push  (default: auto-detected)
+ *       --base <branch>  base branch          (default: master)
+ *       --no-push        create branch + commit but don't push
+ *       --dry-run        build + write files, make no git changes
+ *       --keep-image     keep the Docker image afterwards
+ *       --force          proceed despite a dirty tree, an existing folder, or a missing tag
+ *   -h, --help
+ *
+ * Requirements: Node >= 18, Docker, git. Optional: gh (GitHub CLI) for auto-PR.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const UPSTREAM = 'rsksmart/reproducible-builds'; // canonical repo, for PR compare URLs
+
+// ---------------------------------------------------------------------------
+// Terminal helpers
+// ---------------------------------------------------------------------------
+
+const useColor = process.stdout.isTTY && !process.env.NO_COLOR;
+const paint = (code, s) => (useColor ? `[${code}m${s}[0m` : s);
+const c = {
+  bold: (s) => paint('1', s),
+  dim: (s) => paint('2', s),
+  red: (s) => paint('31', s),
+  green: (s) => paint('32', s),
+  yellow: (s) => paint('33', s),
+  cyan: (s) => paint('36', s),
+};
+const die = (msg, code = 2) => {
+  console.error(c.red('error: ') + msg);
+  process.exit(code);
+};
+const step = (msg) => console.log(c.cyan('• ') + c.bold(msg));
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+const SEMVER = '\\d+(?:\\.\\d+){1,3}';
+
+const COMPONENTS = {
+  rskj: {
+    name: 'rskj',
+    sourceRepo: 'rsksmart/rskj',
+    subdir: 'rskj',
+    // folder: "<semver>-<codename>" e.g. 9.0.2-vetiver
+    folder: ({ semver, codename }) => `${semver}-${codename.toLowerCase()}`,
+    parseFolder: (name) => {
+      const m = name.match(new RegExp(`^(${SEMVER})-(.+)$`));
+      return m ? { semver: m[1], codename: m[2].toLowerCase() } : null;
+    },
+    fatJar: ({ semver, codename }) => `rskj-core-${semver}-${codename.toUpperCase()}-all.jar`,
+  },
+  'powpeg-node': {
+    name: 'powpeg-node',
+    sourceRepo: 'rsksmart/powpeg-node',
+    subdir: 'powpeg-node',
+    // folder: "<CODENAME>-<semver>" e.g. VETIVER-9.0.0.0 (also the tag)
+    folder: ({ semver, codename }) => `${codename.toUpperCase()}-${semver}`,
+    parseFolder: (name) => {
+      const m = name.match(new RegExp(`^(.+)-(${SEMVER})$`));
+      return m ? { semver: m[2], codename: m[1].toLowerCase() } : null;
+    },
+    fatJar: ({ semver, codename }) => `federate-node-${codename.toUpperCase()}-${semver}-all.jar`,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tag parsing / component inference / version substitution
+// ---------------------------------------------------------------------------
+
+// Tags are "<CODENAME>-<semver>", e.g. VETIVER-9.0.2, HOP-TESTNET-4.0.1.0.
+function parseTag(tag) {
+  const m = String(tag).trim().match(new RegExp(`^(.+)-(${SEMVER})$`));
+  return m ? { codename: m[1].toLowerCase(), semver: m[2] } : null;
+}
+
+// powpeg-node uses 4-part versions (9.0.0.0); rskj uses 3 (9.0.2).
+function inferComponent(parsed) {
+  return parsed && parsed.semver.split('.').length >= 4 ? 'powpeg-node' : 'rskj';
+}
+
+function cmpSemver(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d) return d;
+  }
+  return 0;
+}
+
+// Replace every encoding of the old version with the new one. Each version
+// appears only in these four combined forms (verified against real folders),
+// so there's no risky bare-number substitution.
+function substituteVersion(text, oldP, newP) {
+  const forms = (p) => {
+    const cn = p.codename.toLowerCase();
+    const CN = p.codename.toUpperCase();
+    return [`${CN}-${p.semver}`, `${p.semver}-${CN}`, `${p.semver}-${cn}`, `${cn}-${p.semver}`];
+  };
+  const from = forms(oldP);
+  const to = forms(newP);
+  let out = text;
+  for (let i = 0; i < from.length; i++) out = out.split(from[i]).join(to[i]);
+  return out;
+}
+
+// Replace the contiguous run of "<sha256>  <file>" lines with a fresh block.
+function injectShaBlock(readme, block) {
+  const isHash = (l) => /^[0-9a-fA-F]{64}\s+\S+$/.test(l.trim());
+  const lines = readme.split('\n');
+  let start = lines.findIndex(isHash);
+  if (start === -1) throw new Error('template README has no sha256 block to replace');
+  let end = start;
+  while (end + 1 < lines.length && isHash(lines[end + 1])) end++;
+  lines.splice(start, end - start + 1, ...block.split('\n'));
+  return lines.join('\n');
+}
+
+function parseShaLine(block, filename) {
+  for (const line of block.split('\n')) {
+    const m = line.trim().match(/^([0-9a-fA-F]{64})\s+(\S+)$/);
+    if (m && m[2] === filename) return m[1].toLowerCase();
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Shell / git helpers
+// ---------------------------------------------------------------------------
+
+function run(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...opts });
+  if (r.error) throw r.error;
+  if (!opts.allowFail && r.status !== 0) {
+    throw new Error(`${cmd} ${args.join(' ')} failed: ${(r.stderr || r.stdout || '').trim()}`);
+  }
+  return r;
+}
+const git = (args, cwd, opts = {}) => run('git', args, { cwd, ...opts });
+const has = (cmd) => {
+  const r = spawnSync(cmd, ['--version'], { encoding: 'utf8' });
+  return !r.error && r.status === 0;
+};
+function streaming(cmd, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(cmd, args, { cwd, stdio: 'inherit' });
+    p.on('error', reject);
+    p.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`))));
+  });
+}
+
+function detectRemote(repoDir, override) {
+  if (override) return override;
+  if (process.env.REPRO_REMOTE) return process.env.REPRO_REMOTE;
+  const remotes = git(['remote'], repoDir).stdout.split('\n').map((s) => s.trim()).filter(Boolean);
+  if (remotes.includes('origin')) return 'origin';
+  if (remotes.length) return remotes[0];
+  die('no git remotes configured in this repo.');
+}
+
+function githubSlug(repoDir, remote) {
+  const r = git(['remote', 'get-url', remote], repoDir, { allowFail: true });
+  if (r.status !== 0) return null;
+  const m = r.stdout.trim().match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
+  return m ? m[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub release cross-check
+// ---------------------------------------------------------------------------
+
+function ghHeaders() {
+  const h = { 'User-Agent': 'rsk-build-generator', Accept: 'application/vnd.github+json' };
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (token) h.Authorization = `Bearer ${token}`;
+  return h;
+}
+// Does the git tag exist in the source repo? (This is what we build against —
+// the release comes later.)
+async function tagExists(repo, tag) {
+  const res = await fetch(`https://api.github.com/repos/${repo}/git/ref/tags/${encodeURIComponent(tag)}`, {
+    headers: ghHeaders(),
+  });
+  if (res.status === 404) return false;
+  if (!res.ok) throw new Error(`tag lookup -> ${res.status} ${res.statusText}`);
+  return true;
+}
+
+async function fetchReleaseDigest(repo, tag, fatJarName) {
+  const res = await fetch(`https://api.github.com/repos/${repo}/releases/tags/${tag}`, { headers: ghHeaders() });
+  if (res.status === 404) return { release: null, digest: null };
+  if (!res.ok) throw new Error(`release lookup -> ${res.status} ${res.statusText}`);
+  const rel = await res.json();
+  const a =
+    (rel.assets || []).find((x) => x.name === fatJarName) ||
+    (rel.assets || []).find((x) => x.name.endsWith('-all.jar'));
+  const digest = a && a.digest && a.digest.startsWith('sha256:') ? a.digest.slice(7) : null;
+  return { release: rel, digest };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = { push: true };
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--component' || a === '-c') opts.component = argv[++i];
+    else if (a === '--branch' || a === '-b') opts.branch = argv[++i];
+    else if (a === '--remote') opts.remote = argv[++i];
+    else if (a === '--base') opts.base = argv[++i];
+    else if (a === '--no-push') opts.push = false;
+    else if (a === '--dry-run') opts.dryRun = true;
+    else if (a === '--allow-existing') opts.allowExisting = true;
+    else if (a === '--keep-image') opts.keepImage = true;
+    else if (a === '--force') opts.force = true;
+    else if (a === '--help' || a === '-h') opts.help = true;
+    else positional.push(a);
+  }
+  return { opts, positional };
+}
+
+const USAGE = `${c.bold('Reproducible-build generator')}
+
+Two commands:
+
+  generate (default)  Scaffold, build, verify, commit & push a reproducible
+                      build for a release tag (templated from the newest folder).
+  validate            Reproduce the build proposed in a PR and comment whether
+                      the hashes match.
+
+Usage:
+  node generate-build.js <tag> [options]
+  node generate-build.js validate <pr-url> [--dry-run] [--keep-image]
+
+Tags:
+  VETIVER-9.0.3       rskj (auto-detected: 3-part version)
+  VETIVER-9.0.1.0     powpeg-node (auto-detected: 4-part version)
+
+Generate options:
+  -c, --component <c>  rskj | powpeg-node (default: auto from version shape)
+  -b, --branch <name>  branch to create   (default: repro/<component>-<folder>)
+      --remote <name>  git remote to push (default: auto-detected)
+      --base <branch>  base branch         (default: master)
+      --no-push        create branch + commit but don't push
+      --dry-run        build + write files, make no git changes (skips the exists check)
+      --allow-existing regenerate a build that already exists
+      --keep-image     keep the Docker image afterwards
+      --force          proceed despite a dirty tree, an existing folder, or a missing tag
+  -h, --help
+
+Validate:
+  validate <pr-url>    Reproduce the PR's build and post a PR comment:
+                       "Hashes verified!" or "Hashes differ!!" with the hashes.
+                       --dry-run prints the comment instead of posting.
+                       Exits 0 if they match, 1 if they differ.
+
+Requirements: Node >= 18, Docker. git is needed for generate; a PR comment needs
+gh (GitHub CLI) or GITHUB_TOKEN.
+`;
+
+async function main() {
+  const { opts, positional } = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  // Subcommand: validate a PR by reproducing its build and commenting the result.
+  if (positional[0] === 'validate') {
+    return modeValidate(positional[1], opts);
+  }
+
+  const tag = positional[0];
+  if (!tag) {
+    console.log(USAGE);
+    process.exit(2);
+  }
+
+  const parsed = parseTag(tag);
+  if (!parsed) die(`could not parse tag "${tag}". Expected <CODENAME>-<version>, e.g. VETIVER-9.0.2`);
+  const componentName = opts.component || inferComponent(parsed);
+  const component = COMPONENTS[componentName];
+  if (!component) die(`unknown component "${componentName}". Known: ${Object.keys(COMPONENTS).join(', ')}`);
+
+  const folder = component.folder(parsed);
+  const fatJarName = component.fatJar(parsed);
+  console.log(c.bold(`\n${component.name}  ${tag}`));
+  console.log(c.dim(`  folder: ${component.subdir}/${folder}`));
+  if (!opts.component) console.log(c.dim(`  (auto-detected component: ${componentName} — use --component to override)`));
+
+  if (!has('docker')) die('Docker is required (this generator always builds to compute real hashes).');
+  if (!has('git')) die('git is required.');
+
+  // Repo root = this script's own repository.
+  const repoDir = git(['rev-parse', '--show-toplevel'], __dirname, { allowFail: true }).stdout.trim();
+  if (!repoDir) die('this script must live inside the reproducible-builds git repository.');
+
+  const remote = detectRemote(repoDir, opts.remote);
+  const base = opts.base || process.env.REPRO_BASE_BRANCH || 'master';
+  const branch = opts.branch || `repro/${component.name}-${folder}`;
+
+  // Guard: dirty tree (ignore untracked files like this script itself).
+  const dirty = git(['status', '--porcelain', '--untracked-files=no'], repoDir).stdout.trim();
+  if (dirty && !opts.force) die(`working tree is not clean. Commit/stash first or use --force.\n${dirty}`);
+
+  // Fetch the base up front so existence checks and branching see the latest state.
+  step(`Fetching ${remote}/${base}`);
+  git(['fetch', remote, base], repoDir);
+
+  const relFolder = path.join(component.subdir, folder);
+  const folderPath = path.join(repoDir, relFolder);
+  // Refuse if the build already exists either on disk OR upstream on the base
+  // branch (your local checkout may simply be behind — that was the cause of
+  // the "untracked files would be overwritten by checkout" error).
+  const existsLocal = fs.existsSync(folderPath);
+  const existsUpstream =
+    git(['ls-tree', '-r', '--name-only', `${remote}/${base}`, '--', relFolder], repoDir, { allowFail: true })
+      .stdout.trim().length > 0;
+  const exists = existsLocal || existsUpstream;
+  // --dry-run never commits, and --allow-existing / --force are explicit opt-ins
+  // to regenerate. Otherwise refuse, so we don't open a duplicate PR.
+  const mayProceedIfExists = opts.dryRun || opts.allowExisting || opts.force;
+  if (exists) {
+    const where = existsUpstream ? `already exists on ${remote}/${base}` : 'already exists locally';
+    if (!mayProceedIfExists) {
+      die(
+        `target ${relFolder} ${where} (already published?).\n` +
+          `  To regenerate it for testing, add --allow-existing or --dry-run;\n` +
+          `  use --force to overwrite and commit.`,
+      );
+    }
+    console.log(c.yellow(`  note: ${relFolder} ${where}; regenerating (you'll see "nothing to commit" if it reproduces).`));
+  }
+
+  // Pre-flight: the source tag must exist (this is what we build — the GitHub
+  // *release* is published only AFTER the reproducible build is accepted, so we
+  // do not require/gate on it here). Fail fast before the long Docker build.
+  step(`Checking tag ${tag} exists in ${component.sourceRepo}`);
+  let tagOk = true;
+  try {
+    tagOk = await tagExists(component.sourceRepo, tag);
+  } catch (e) {
+    console.log(c.yellow(`  could not verify the tag (${e.message}); continuing.`));
+  }
+  if (!tagOk && !opts.force) {
+    die(`tag "${tag}" not found in ${component.sourceRepo}. Check the tag name, or use --force to build anyway.`, 1);
+  }
+  if (tagOk) console.log(c.green('  ✔ tag found'));
+
+  // Template = newest existing folder for this component.
+  const subdirPath = path.join(repoDir, component.subdir);
+  const templates = fs
+    .readdirSync(subdirPath, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => ({ name: d.name, p: component.parseFolder(d.name) }))
+    .filter((x) => x.p && x.name !== folder)
+    .sort((a, b) => cmpSemver(b.p.semver, a.p.semver));
+  if (!templates.length) die(`no existing ${component.subdir} folder to use as a template.`);
+  const template = templates[0];
+  step(`Using ${component.subdir}/${template.name} as the template`);
+
+  const tplDockerfile = fs.readFileSync(path.join(subdirPath, template.name, 'Dockerfile'), 'utf8');
+  const tplReadme = fs.readFileSync(path.join(subdirPath, template.name, 'README.md'), 'utf8');
+
+  const dockerfile = substituteVersion(tplDockerfile, template.p, parsed);
+
+  // Build in a temporary context so the repo working tree is never touched
+  // until we have a verified result. (Avoids leaving untracked files behind on
+  // a failed build, and avoids colliding with the upcoming branch checkout.)
+  const buildDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rsk-build-'));
+  fs.writeFileSync(path.join(buildDir, 'Dockerfile'), dockerfile);
+
+  const imageTag = `${component.name}/${folder}`.toLowerCase();
+  step(`Building ${imageTag} with Docker (compiles ${component.name} from source — can take a while)`);
+  try {
+    await streaming('docker', ['build', '-t', imageTag, buildDir], repoDir);
+  } catch (e) {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+    die(`docker build failed: ${e.message}`, 1);
+  }
+
+  step('Hashing built artifacts');
+  const shell = componentShell(tplReadme); // mirror the shell the template README documents
+  const shaBlock = run('docker', ['run', '--rm', imageTag, shell, '-c', 'sha256sum * | grep -v javadoc.jar']).stdout.trim();
+  fs.rmSync(buildDir, { recursive: true, force: true });
+  if (!shaBlock) die('the built image produced no artifacts to hash.', 1);
+  console.log(shaBlock.split('\n').map((l) => '    ' + l).join('\n'));
+  if (!opts.keepImage) spawnSync('docker', ['image', 'rm', '-f', imageTag], { stdio: 'ignore' });
+
+  // Informational only: if a GitHub release already exists for this tag, note
+  // whether our fat jar matches it. Normally there is NO release yet (it's
+  // published after the reproducible build is accepted), so this is skipped.
+  // This is never a gate — the reproducible build is the source of truth.
+  step('Comparing against a published GitHub release (if one exists yet)');
+  const built = parseShaLine(shaBlock, fatJarName);
+  let declared = null;
+  try {
+    ({ digest: declared } = await fetchReleaseDigest(component.sourceRepo, tag, fatJarName));
+  } catch (e) {
+    console.log(c.yellow(`  could not query the release (${e.message}); skipping.`));
+  }
+  if (declared && built) {
+    if (declared === built) console.log(c.green(`  ✔ matches the existing release digest (${built.slice(0, 16)}…)`));
+    else
+      console.log(
+        c.red(`  ✘ differs from the existing release digest:\n    built:   ${built}\n    release: ${declared}`) +
+          c.yellow('\n  (the reproducible build is authoritative — investigate if this is unexpected.)'),
+      );
+  } else {
+    console.log(c.dim('  no release yet — expected (releases are published after the build is accepted); skipping.'));
+  }
+
+  const readme = injectShaBlock(substituteVersion(tplReadme, template.p, parsed), shaBlock);
+
+  // Helper: write the two files into the repo folder.
+  const writeFiles = () => {
+    fs.mkdirSync(folderPath, { recursive: true });
+    fs.writeFileSync(path.join(folderPath, 'Dockerfile'), dockerfile);
+    fs.writeFileSync(path.join(folderPath, 'README.md'), readme);
+  };
+
+  if (opts.dryRun) {
+    step('Writing files (dry-run)');
+    writeFiles();
+    console.log(c.yellow(`\n--dry-run: wrote ${relFolder}; no git changes made.`));
+    return;
+  }
+
+  // Create the branch BEFORE writing any files into the repo, so a clean tree
+  // is checked out and there are no untracked files to collide with.
+  step(`Creating branch ${branch} off ${remote}/${base}`);
+  git(['checkout', '-B', branch, `${remote}/${base}`], repoDir);
+
+  step('Writing files');
+  writeFiles();
+
+  step('Committing');
+  git(['add', '--', relFolder], repoDir);
+  if (git(['diff', '--cached', '--quiet'], repoDir, { allowFail: true }).status === 0) {
+    console.log(c.yellow(`  nothing to commit — generated files are identical to ${remote}/${base}.`));
+    console.log(c.green('\n✔ done (no changes).\n'));
+    return;
+  }
+  git(['commit', '-m', `Add ${component.name} reproducible build for ${tag}`], repoDir);
+
+  if (opts.push) {
+    step(`Pushing to ${remote}/${branch}`);
+    git(['push', '-u', remote, branch], repoDir);
+    openPr({ repoDir, remote, base, branch, component, tag, version: parsed.semver, shaBlock });
+  } else {
+    console.log(c.yellow(`\n  --no-push: publish with:  git -C "${repoDir}" push -u ${remote} ${branch}`));
+  }
+
+  console.log(c.green('\n✔ done.\n'));
+}
+
+// Mirror the shell the template README uses in its "docker run ... -c" line.
+function componentShell(readme) {
+  return /docker run[^\n]*\bbash -c\b/.test(readme) ? 'bash' : 'sh';
+}
+
+// A fenced code block listing the artifacts and their hashes.
+function hashFence(shaBlock) {
+  return '```\n' + shaBlock + '\n```';
+}
+
+function openPr({ repoDir, remote, base, branch, component, tag, version, shaBlock }) {
+  const title = `Add ${component.name} reproducible build for ${tag}`;
+  const body = `${component.name} reproducible build for version ${version}\n\n${hashFence(shaBlock)}\n`;
+
+  if (has('gh')) {
+    step('Opening a PR with gh');
+    const r = spawnSync(
+      'gh',
+      ['pr', 'create', '--repo', UPSTREAM, '--base', base, '--head', branch, '--title', title, '--body', body],
+      { cwd: repoDir, stdio: 'inherit' },
+    );
+    if (!r.error && r.status === 0) return;
+    console.log(c.yellow('  gh pr create did not complete — here is the info to open it manually:'));
+  } else {
+    step('PR info (gh not found — copy/paste to open the PR)');
+  }
+  const slug = githubSlug(repoDir, remote);
+  const owner = slug ? slug.split('/')[0] : null;
+  const head = owner && owner !== UPSTREAM.split('/')[0] ? `${owner}:${branch}` : branch;
+  const q = `expand=1&title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+  console.log(`  title: ${title}`);
+  console.log(`  body:\n${body.split('\n').map((l) => '    ' + l).join('\n')}`);
+  console.log(`  url:   https://github.com/${UPSTREAM}/compare/${base}...${encodeURIComponent(head)}?${q}`);
+}
+
+// ---------------------------------------------------------------------------
+// validate mode: reproduce a PR's build and comment the result
+// ---------------------------------------------------------------------------
+
+function parsePrUrl(url) {
+  const m = String(url || '').match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  return m ? { owner: m[1], repo: m[2], number: m[3] } : null;
+}
+
+async function ghJson(url) {
+  const res = await fetch(url, { headers: ghHeaders() });
+  if (res.status === 404) throw new Error(`not found: ${url}`);
+  if (!res.ok) throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+async function fetchTextOrDie(url, label) {
+  const res = await fetch(url, { headers: { 'User-Agent': 'rsk-build-generator' } });
+  if (!res.ok) die(`could not fetch ${label} from the PR (${res.status} ${res.statusText}):\n  ${url}`, 1);
+  return res.text();
+}
+
+// Map filename -> hash from a "<sha256>  <file>" block.
+function parseShaMap(text) {
+  const map = new Map();
+  for (const line of String(text).split('\n')) {
+    const m = line.trim().match(/^([0-9a-fA-F]{64})\s+(\S+)$/);
+    if (m) map.set(m[2], m[1].toLowerCase());
+  }
+  return map;
+}
+
+function mapsEqual(a, b) {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) if (b.get(k) !== v) return false;
+  return true;
+}
+
+// Identify which build folder a PR adds from its changed file paths.
+function detectBuildFromFiles(filenames) {
+  const found = new Map();
+  for (const f of filenames) {
+    const m = String(f).match(/^(rskj|powpeg-node)\/([^/]+)\//);
+    if (!m) continue;
+    const component = COMPONENTS[m[1]];
+    if (component && component.parseFolder(m[2])) found.set(`${m[1]}/${m[2]}`, { component, folder: m[2] });
+  }
+  const vals = [...found.values()];
+  if (vals.length === 1) return vals[0];
+  if (vals.length > 1) die(`PR touches multiple build folders: ${[...found.keys()].join(', ')}. Validate one at a time.`);
+  return null;
+}
+
+async function postComment(prUrl, pr, body) {
+  if (has('gh')) {
+    const r = spawnSync('gh', ['pr', 'comment', prUrl, '--body', body], { stdio: 'inherit' });
+    if (!r.error && r.status === 0) return console.log(c.green('  comment posted.'));
+    console.log(c.yellow('  gh pr comment did not complete; trying the API…'));
+  }
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (token) {
+    const res = await fetch(`https://api.github.com/repos/${pr.owner}/${pr.repo}/issues/${pr.number}/comments`, {
+      method: 'POST',
+      headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+    if (res.ok) return console.log(c.green('  comment posted.'));
+    console.log(c.yellow(`  API comment failed: ${res.status} ${res.statusText}`));
+  }
+  console.log(c.yellow('\n  Could not post automatically (need `gh` or GITHUB_TOKEN). Comment to paste:\n'));
+  console.log(body.split('\n').map((l) => '    ' + l).join('\n'));
+}
+
+async function modeValidate(prUrl, opts) {
+  const pr = parsePrUrl(prUrl);
+  if (!pr) die('validate needs a PR URL, e.g.\n  node generate-build.js validate https://github.com/rsksmart/reproducible-builds/pull/123');
+  if (!has('docker')) die('Docker is required to reproduce the build.');
+
+  console.log(c.bold(`\nValidating PR #${pr.number} in ${pr.owner}/${pr.repo}`));
+
+  // 1. PR head (repo + ref) and the build folder it adds.
+  step('Fetching PR metadata');
+  const meta = await ghJson(`https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`);
+  const headRepo = meta.head && meta.head.repo ? meta.head.repo.full_name : `${pr.owner}/${pr.repo}`;
+  const headRef = meta.head && meta.head.ref;
+  if (!headRef) die('could not determine the PR head ref.', 1);
+
+  const files = await ghJson(`https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}/files?per_page=100`);
+  const build = detectBuildFromFiles(files.map((f) => f.filename));
+  if (!build) die('this PR does not add a recognized rskj/ or powpeg-node/ build folder.', 1);
+  const { component, folder } = build;
+  console.log(c.dim(`  build: ${component.subdir}/${folder}   (head ${headRepo}@${headRef})`));
+
+  // 2. Fetch the PR's Dockerfile + README from the head ref.
+  const rawBase = `https://raw.githubusercontent.com/${headRepo}/${encodeURIComponent(headRef)}/${component.subdir}/${folder}`;
+  step('Fetching the build files from the PR');
+  const dockerfile = await fetchTextOrDie(`${rawBase}/Dockerfile`, 'Dockerfile');
+  const prReadme = await fetchTextOrDie(`${rawBase}/README.md`, 'README.md');
+  const declared = parseShaMap(prReadme);
+  if (!declared.size) die('the PR README has no sha256 block to compare against.', 1);
+
+  // 3. Reproduce.
+  const buildDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rsk-validate-'));
+  fs.writeFileSync(path.join(buildDir, 'Dockerfile'), dockerfile);
+  const imageTag = `${component.name}/${folder}`.toLowerCase() + ':validate';
+  step(`Building ${imageTag} (compiles ${component.name} from source — can take a while)`);
+  try {
+    await streaming('docker', ['build', '-t', imageTag, buildDir]);
+  } catch (e) {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+    die(`docker build failed: ${e.message}`, 1);
+  }
+  step('Hashing built artifacts');
+  const shell = componentShell(prReadme);
+  const reproBlock = run('docker', ['run', '--rm', imageTag, shell, '-c', 'sha256sum * | grep -v javadoc.jar']).stdout.trim();
+  fs.rmSync(buildDir, { recursive: true, force: true });
+  if (!opts.keepImage) spawnSync('docker', ['image', 'rm', '-f', imageTag], { stdio: 'ignore' });
+  if (!reproBlock) die('the built image produced no artifacts to hash.', 1);
+  console.log(reproBlock.split('\n').map((l) => '    ' + l).join('\n'));
+
+  // 4. Compare reproduced vs the hashes declared in the PR's README.md file
+  //    (the source of truth — the PR description text is irrelevant here).
+  const reproduced = parseShaMap(reproBlock);
+  const matches = mapsEqual(declared, reproduced);
+  if (matches) {
+    console.log(c.green('\n  ✔ reproduced hashes match the PR.'));
+  } else {
+    console.log(c.red('\n  ✘ reproduced hashes do NOT match the PR:'));
+    const names = new Set([...declared.keys(), ...reproduced.keys()]);
+    for (const n of names) {
+      if (declared.get(n) !== reproduced.get(n)) {
+        console.log(c.dim(`    ${n}: PR=${declared.get(n) || '(absent)'}  built=${reproduced.get(n) || '(absent)'}`));
+      }
+    }
+  }
+
+  // 5. Comment.
+  const body = `${matches ? 'Hashes verified!' : 'Hashes differ!!'}\n\n${hashFence(reproBlock)}\n`;
+  if (opts.dryRun) {
+    console.log(c.yellow('\n--dry-run: not posting. The comment would be:\n'));
+    console.log(body.split('\n').map((l) => '    ' + l).join('\n'));
+  } else {
+    step('Posting the result as a PR comment');
+    await postComment(prUrl, pr, body);
+  }
+  process.exit(matches ? 0 : 1);
+}
+
+if (require.main === module) {
+  main().catch((e) => die(e.stack || e.message, 1));
+}
+
+module.exports = {
+  COMPONENTS,
+  parseTag,
+  inferComponent,
+  cmpSemver,
+  substituteVersion,
+  injectShaBlock,
+  parseShaLine,
+  parseShaMap,
+  mapsEqual,
+  componentShell,
+  githubSlug,
+  hashFence,
+  parsePrUrl,
+  detectBuildFromFiles,
+};

--- a/scripts/generate-build.js
+++ b/scripts/generate-build.js
@@ -50,6 +50,24 @@ const { spawn, spawnSync } = require('child_process');
 
 const UPSTREAM = 'rsksmart/reproducible-builds'; // canonical repo, for PR compare URLs
 
+// Pure logic (component conventions, parsing, substitution, sha handling) lives
+// in lib.js and is unit-tested in lib.test.js. This file is the I/O + flows.
+const {
+  COMPONENTS,
+  parseTag,
+  inferComponent,
+  cmpSemver,
+  substituteVersion,
+  injectShaBlock,
+  parseShaLine,
+  parseShaMap,
+  mapsEqual,
+  componentShell,
+  hashFence,
+  parsePrUrl,
+  detectBuildFromFiles,
+} = require('./lib');
+
 // ---------------------------------------------------------------------------
 // Terminal helpers
 // ---------------------------------------------------------------------------
@@ -69,100 +87,6 @@ const die = (msg, code = 2) => {
   process.exit(code);
 };
 const step = (msg) => console.log(c.cyan('• ') + c.bold(msg));
-
-// ---------------------------------------------------------------------------
-// Components
-// ---------------------------------------------------------------------------
-
-const SEMVER = '\\d+(?:\\.\\d+){1,3}';
-
-const COMPONENTS = {
-  rskj: {
-    name: 'rskj',
-    sourceRepo: 'rsksmart/rskj',
-    subdir: 'rskj',
-    // folder: "<semver>-<codename>" e.g. 9.0.2-vetiver
-    folder: ({ semver, codename }) => `${semver}-${codename.toLowerCase()}`,
-    parseFolder: (name) => {
-      const m = name.match(new RegExp(`^(${SEMVER})-(.+)$`));
-      return m ? { semver: m[1], codename: m[2].toLowerCase() } : null;
-    },
-    fatJar: ({ semver, codename }) => `rskj-core-${semver}-${codename.toUpperCase()}-all.jar`,
-  },
-  'powpeg-node': {
-    name: 'powpeg-node',
-    sourceRepo: 'rsksmart/powpeg-node',
-    subdir: 'powpeg-node',
-    // folder: "<CODENAME>-<semver>" e.g. VETIVER-9.0.0.0 (also the tag)
-    folder: ({ semver, codename }) => `${codename.toUpperCase()}-${semver}`,
-    parseFolder: (name) => {
-      const m = name.match(new RegExp(`^(.+)-(${SEMVER})$`));
-      return m ? { semver: m[2], codename: m[1].toLowerCase() } : null;
-    },
-    fatJar: ({ semver, codename }) => `federate-node-${codename.toUpperCase()}-${semver}-all.jar`,
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Tag parsing / component inference / version substitution
-// ---------------------------------------------------------------------------
-
-// Tags are "<CODENAME>-<semver>", e.g. VETIVER-9.0.2, HOP-TESTNET-4.0.1.0.
-function parseTag(tag) {
-  const m = String(tag).trim().match(new RegExp(`^(.+)-(${SEMVER})$`));
-  return m ? { codename: m[1].toLowerCase(), semver: m[2] } : null;
-}
-
-// powpeg-node uses 4-part versions (9.0.0.0); rskj uses 3 (9.0.2).
-function inferComponent(parsed) {
-  return parsed && parsed.semver.split('.').length >= 4 ? 'powpeg-node' : 'rskj';
-}
-
-function cmpSemver(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const d = (pa[i] || 0) - (pb[i] || 0);
-    if (d) return d;
-  }
-  return 0;
-}
-
-// Replace every encoding of the old version with the new one. Each version
-// appears only in these four combined forms (verified against real folders),
-// so there's no risky bare-number substitution.
-function substituteVersion(text, oldP, newP) {
-  const forms = (p) => {
-    const cn = p.codename.toLowerCase();
-    const CN = p.codename.toUpperCase();
-    return [`${CN}-${p.semver}`, `${p.semver}-${CN}`, `${p.semver}-${cn}`, `${cn}-${p.semver}`];
-  };
-  const from = forms(oldP);
-  const to = forms(newP);
-  let out = text;
-  for (let i = 0; i < from.length; i++) out = out.split(from[i]).join(to[i]);
-  return out;
-}
-
-// Replace the contiguous run of "<sha256>  <file>" lines with a fresh block.
-function injectShaBlock(readme, block) {
-  const isHash = (l) => /^[0-9a-fA-F]{64}\s+\S+$/.test(l.trim());
-  const lines = readme.split('\n');
-  let start = lines.findIndex(isHash);
-  if (start === -1) throw new Error('template README has no sha256 block to replace');
-  let end = start;
-  while (end + 1 < lines.length && isHash(lines[end + 1])) end++;
-  lines.splice(start, end - start + 1, ...block.split('\n'));
-  return lines.join('\n');
-}
-
-function parseShaLine(block, filename) {
-  for (const line of block.split('\n')) {
-    const m = line.trim().match(/^([0-9a-fA-F]{64})\s+(\S+)$/);
-    if (m && m[2] === filename) return m[1].toLowerCase();
-  }
-  return null;
-}
 
 // ---------------------------------------------------------------------------
 // Shell / git helpers
@@ -497,16 +421,6 @@ async function main() {
   console.log(c.green('\n✔ done.\n'));
 }
 
-// Mirror the shell the template README uses in its "docker run ... -c" line.
-function componentShell(readme) {
-  return /docker run[^\n]*\bbash -c\b/.test(readme) ? 'bash' : 'sh';
-}
-
-// A fenced code block listing the artifacts and their hashes.
-function hashFence(shaBlock) {
-  return '```\n' + shaBlock + '\n```';
-}
-
 function openPr({ repoDir, remote, base, branch, component, tag, version, shaBlock }) {
   const title = `Add ${component.name} reproducible build for ${tag}`;
   const body = `${component.name} reproducible build for version ${version}\n\n${hashFence(shaBlock)}\n`;
@@ -536,11 +450,6 @@ function openPr({ repoDir, remote, base, branch, component, tag, version, shaBlo
 // validate mode: reproduce a PR's build and comment the result
 // ---------------------------------------------------------------------------
 
-function parsePrUrl(url) {
-  const m = String(url || '').match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
-  return m ? { owner: m[1], repo: m[2], number: m[3] } : null;
-}
-
 async function ghJson(url) {
   const res = await fetch(url, { headers: ghHeaders() });
   if (res.status === 404) throw new Error(`not found: ${url}`);
@@ -552,37 +461,6 @@ async function fetchTextOrDie(url, label) {
   const res = await fetch(url, { headers: { 'User-Agent': 'rsk-build-generator' } });
   if (!res.ok) die(`could not fetch ${label} from the PR (${res.status} ${res.statusText}):\n  ${url}`, 1);
   return res.text();
-}
-
-// Map filename -> hash from a "<sha256>  <file>" block.
-function parseShaMap(text) {
-  const map = new Map();
-  for (const line of String(text).split('\n')) {
-    const m = line.trim().match(/^([0-9a-fA-F]{64})\s+(\S+)$/);
-    if (m) map.set(m[2], m[1].toLowerCase());
-  }
-  return map;
-}
-
-function mapsEqual(a, b) {
-  if (a.size !== b.size) return false;
-  for (const [k, v] of a) if (b.get(k) !== v) return false;
-  return true;
-}
-
-// Identify which build folder a PR adds from its changed file paths.
-function detectBuildFromFiles(filenames) {
-  const found = new Map();
-  for (const f of filenames) {
-    const m = String(f).match(/^(rskj|powpeg-node)\/([^/]+)\//);
-    if (!m) continue;
-    const component = COMPONENTS[m[1]];
-    if (component && component.parseFolder(m[2])) found.set(`${m[1]}/${m[2]}`, { component, folder: m[2] });
-  }
-  const vals = [...found.values()];
-  if (vals.length === 1) return vals[0];
-  if (vals.length > 1) die(`PR touches multiple build folders: ${[...found.keys()].join(', ')}. Validate one at a time.`);
-  return null;
 }
 
 async function postComment(prUrl, pr, body) {
@@ -620,7 +498,12 @@ async function modeValidate(prUrl, opts) {
   if (!headRef) die('could not determine the PR head ref.', 1);
 
   const files = await ghJson(`https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}/files?per_page=100`);
-  const build = detectBuildFromFiles(files.map((f) => f.filename));
+  let build;
+  try {
+    build = detectBuildFromFiles(files.map((f) => f.filename));
+  } catch (e) {
+    die(e.message, 1); // e.g. PR touches multiple build folders
+  }
   if (!build) die('this PR does not add a recognized rskj/ or powpeg-node/ build folder.', 1);
   const { component, folder } = build;
   console.log(c.dim(`  build: ${component.subdir}/${folder}   (head ${headRepo}@${headRef})`));
@@ -683,20 +566,3 @@ async function modeValidate(prUrl, opts) {
 if (require.main === module) {
   main().catch((e) => die(e.stack || e.message, 1));
 }
-
-module.exports = {
-  COMPONENTS,
-  parseTag,
-  inferComponent,
-  cmpSemver,
-  substituteVersion,
-  injectShaBlock,
-  parseShaLine,
-  parseShaMap,
-  mapsEqual,
-  componentShell,
-  githubSlug,
-  hashFence,
-  parsePrUrl,
-  detectBuildFromFiles,
-};

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -1,0 +1,167 @@
+'use strict';
+
+/*
+ * Pure logic for the reproducible-build generator: component conventions, tag
+ * parsing, version substitution, README sha-block handling, and PR helpers.
+ *
+ * Everything here is deterministic and side-effect free (no git, Docker,
+ * network, filesystem, or process.exit), so it can be unit-tested directly.
+ * See lib.test.js. The I/O and the generate/validate flows live in
+ * generate-build.js.
+ */
+
+// A semver is 2-4 dot-separated numeric parts (rskj uses 3, e.g. 9.0.2;
+// powpeg-node uses 4, e.g. 9.0.0.0).
+const SEMVER = '\\d+(?:\\.\\d+){1,3}';
+
+// Per-component conventions. `folder` and `parseFolder` are inverses.
+const COMPONENTS = {
+  rskj: {
+    name: 'rskj',
+    sourceRepo: 'rsksmart/rskj',
+    subdir: 'rskj',
+    // folder: "<semver>-<codename>" e.g. 9.0.2-vetiver
+    folder: ({ semver, codename }) => `${semver}-${codename.toLowerCase()}`,
+    parseFolder: (name) => {
+      const m = name.match(new RegExp(`^(${SEMVER})-(.+)$`));
+      return m ? { semver: m[1], codename: m[2].toLowerCase() } : null;
+    },
+    fatJar: ({ semver, codename }) => `rskj-core-${semver}-${codename.toUpperCase()}-all.jar`,
+  },
+  'powpeg-node': {
+    name: 'powpeg-node',
+    sourceRepo: 'rsksmart/powpeg-node',
+    subdir: 'powpeg-node',
+    // folder: "<CODENAME>-<semver>" e.g. VETIVER-9.0.0.0 (also the tag)
+    folder: ({ semver, codename }) => `${codename.toUpperCase()}-${semver}`,
+    parseFolder: (name) => {
+      const m = name.match(new RegExp(`^(.+)-(${SEMVER})$`));
+      return m ? { semver: m[2], codename: m[1].toLowerCase() } : null;
+    },
+    fatJar: ({ semver, codename }) => `federate-node-${codename.toUpperCase()}-${semver}-all.jar`,
+  },
+};
+
+// Tags are "<CODENAME>-<semver>", e.g. VETIVER-9.0.2, HOP-TESTNET-4.0.1.0.
+function parseTag(tag) {
+  const m = String(tag).trim().match(new RegExp(`^(.+)-(${SEMVER})$`));
+  return m ? { codename: m[1].toLowerCase(), semver: m[2] } : null;
+}
+
+// powpeg-node uses 4-part versions (9.0.0.0); rskj uses 3 (9.0.2).
+function inferComponent(parsed) {
+  return parsed && parsed.semver.split('.').length >= 4 ? 'powpeg-node' : 'rskj';
+}
+
+function cmpSemver(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d) return d;
+  }
+  return 0;
+}
+
+// Replace every encoding of the old version with the new one. Each version
+// appears only in these four combined forms (verified against real folders),
+// so there's no risky bare-number substitution.
+function substituteVersion(text, oldP, newP) {
+  const forms = (p) => {
+    const cn = p.codename.toLowerCase();
+    const CN = p.codename.toUpperCase();
+    return [`${CN}-${p.semver}`, `${p.semver}-${CN}`, `${p.semver}-${cn}`, `${cn}-${p.semver}`];
+  };
+  const from = forms(oldP);
+  const to = forms(newP);
+  let out = text;
+  for (let i = 0; i < from.length; i++) out = out.split(from[i]).join(to[i]);
+  return out;
+}
+
+// Replace the contiguous run of "<sha256>  <file>" lines with a fresh block.
+function injectShaBlock(readme, block) {
+  const isHash = (l) => /^[0-9a-fA-F]{64}\s+\S+$/.test(l.trim());
+  const lines = readme.split('\n');
+  const start = lines.findIndex(isHash);
+  if (start === -1) throw new Error('template README has no sha256 block to replace');
+  let end = start;
+  while (end + 1 < lines.length && isHash(lines[end + 1])) end++;
+  lines.splice(start, end - start + 1, ...block.split('\n'));
+  return lines.join('\n');
+}
+
+// First hash matching a given filename in a "<sha256>  <file>" block.
+function parseShaLine(block, filename) {
+  for (const line of block.split('\n')) {
+    const m = line.trim().match(/^([0-9a-fA-F]{64})\s+(\S+)$/);
+    if (m && m[2] === filename) return m[1].toLowerCase();
+  }
+  return null;
+}
+
+// Map filename -> hash from a "<sha256>  <file>" block.
+function parseShaMap(text) {
+  const map = new Map();
+  for (const line of String(text).split('\n')) {
+    const m = line.trim().match(/^([0-9a-fA-F]{64})\s+(\S+)$/);
+    if (m) map.set(m[2], m[1].toLowerCase());
+  }
+  return map;
+}
+
+function mapsEqual(a, b) {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) if (b.get(k) !== v) return false;
+  return true;
+}
+
+// Mirror the shell the template README uses in its "docker run ... -c" line.
+function componentShell(readme) {
+  return /docker run[^\n]*\bbash -c\b/.test(readme) ? 'bash' : 'sh';
+}
+
+// A fenced code block listing the artifacts and their hashes.
+function hashFence(shaBlock) {
+  return '```\n' + shaBlock + '\n```';
+}
+
+// Parse a PR web URL into { owner, repo, number }.
+function parsePrUrl(url) {
+  const m = String(url || '').match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  return m ? { owner: m[1], repo: m[2], number: m[3] } : null;
+}
+
+// Identify which build folder a PR adds from its changed file paths. Returns
+// { component, folder } | null. Throws if the PR touches more than one build.
+function detectBuildFromFiles(filenames) {
+  const found = new Map();
+  for (const f of filenames) {
+    const m = String(f).match(/^(rskj|powpeg-node)\/([^/]+)\//);
+    if (!m) continue;
+    const component = COMPONENTS[m[1]];
+    if (component && component.parseFolder(m[2])) found.set(`${m[1]}/${m[2]}`, { component, folder: m[2] });
+  }
+  const vals = [...found.values()];
+  if (vals.length > 1) {
+    throw new Error(`PR touches multiple build folders: ${[...found.keys()].join(', ')}. Validate one at a time.`);
+  }
+  return vals[0] || null;
+}
+
+module.exports = {
+  SEMVER,
+  COMPONENTS,
+  parseTag,
+  inferComponent,
+  cmpSemver,
+  substituteVersion,
+  injectShaBlock,
+  parseShaLine,
+  parseShaMap,
+  mapsEqual,
+  componentShell,
+  hashFence,
+  parsePrUrl,
+  detectBuildFromFiles,
+};

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -23,7 +23,7 @@ const COMPONENTS = {
     // folder: "<semver>-<codename>" e.g. 9.0.2-vetiver
     folder: ({ semver, codename }) => `${semver}-${codename.toLowerCase()}`,
     parseFolder: (name) => {
-      const m = name.match(new RegExp(`^(${SEMVER})-(.+)$`));
+      const m = name.match(new RegExp(`^(${SEMVER})-([A-Za-z0-9-]+)$`));
       return m ? { semver: m[1], codename: m[2].toLowerCase() } : null;
     },
     fatJar: ({ semver, codename }) => `rskj-core-${semver}-${codename.toUpperCase()}-all.jar`,
@@ -35,7 +35,7 @@ const COMPONENTS = {
     // folder: "<CODENAME>-<semver>" e.g. VETIVER-9.0.0.0 (also the tag)
     folder: ({ semver, codename }) => `${codename.toUpperCase()}-${semver}`,
     parseFolder: (name) => {
-      const m = name.match(new RegExp(`^(.+)-(${SEMVER})$`));
+      const m = name.match(new RegExp(`^([A-Za-z0-9-]+)-(${SEMVER})$`));
       return m ? { semver: m[2], codename: m[1].toLowerCase() } : null;
     },
     fatJar: ({ semver, codename }) => `federate-node-${codename.toUpperCase()}-${semver}-all.jar`,
@@ -44,7 +44,7 @@ const COMPONENTS = {
 
 // Tags are "<CODENAME>-<semver>", e.g. VETIVER-9.0.2, HOP-TESTNET-4.0.1.0.
 function parseTag(tag) {
-  const m = String(tag).trim().match(new RegExp(`^(.+)-(${SEMVER})$`));
+  const m = String(tag).trim().match(new RegExp(`^([A-Za-z0-9-]+)-(${SEMVER})$`));
   return m ? { codename: m[1].toLowerCase(), semver: m[2] } : null;
 }
 

--- a/scripts/lib.test.js
+++ b/scripts/lib.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+// Unit tests for the pure logic in lib.js. Run with:
+//   node --test scripts/
+// or
+//   node scripts/lib.test.js
+//
+// Hermetic: uses small inline fixtures, no repo files, network, or Docker.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const lib = require('./lib');
+
+// --- tag parsing ------------------------------------------------------------
+
+test('parseTag: rskj 3-part', () => {
+  assert.deepEqual(lib.parseTag('VETIVER-9.0.2'), { codename: 'vetiver', semver: '9.0.2' });
+});
+test('parseTag: powpeg 4-part', () => {
+  assert.deepEqual(lib.parseTag('VETIVER-9.0.0.0'), { codename: 'vetiver', semver: '9.0.0.0' });
+});
+test('parseTag: dashed codename', () => {
+  assert.deepEqual(lib.parseTag('HOP-TESTNET-4.0.1.0'), { codename: 'hop-testnet', semver: '4.0.1.0' });
+});
+test('parseTag: garbage returns null', () => {
+  assert.equal(lib.parseTag('not-a-tag'), null);
+});
+
+// --- component inference ----------------------------------------------------
+
+test('inferComponent: 3-part -> rskj', () => {
+  assert.equal(lib.inferComponent(lib.parseTag('VETIVER-9.0.2')), 'rskj');
+});
+test('inferComponent: 4-part -> powpeg-node', () => {
+  assert.equal(lib.inferComponent(lib.parseTag('VETIVER-9.0.0.0')), 'powpeg-node');
+});
+
+// --- semver compare ---------------------------------------------------------
+
+test('cmpSemver: numeric ordering (not lexical)', () => {
+  assert.ok(lib.cmpSemver('9.0.2', '9.0.10') < 0);
+  assert.ok(lib.cmpSemver('9.0.0.0', '8.1.0.0') > 0);
+  assert.equal(lib.cmpSemver('1.2.3', '1.2.3'), 0);
+});
+
+// --- component folder <-> parse round-trips ---------------------------------
+
+test('rskj: folder / parseFolder / fatJar', () => {
+  const rskj = lib.COMPONENTS.rskj;
+  const ctx = { semver: '9.0.2', codename: 'vetiver' };
+  assert.equal(rskj.folder(ctx), '9.0.2-vetiver');
+  assert.deepEqual(rskj.parseFolder('9.0.2-vetiver'), { semver: '9.0.2', codename: 'vetiver' });
+  assert.deepEqual(rskj.parseFolder('4.0.1-hop-testnet'), { semver: '4.0.1', codename: 'hop-testnet' });
+  assert.equal(rskj.parseFolder('bouncycastle'), null);
+  assert.equal(rskj.fatJar(ctx), 'rskj-core-9.0.2-VETIVER-all.jar');
+});
+test('powpeg-node: folder / parseFolder / fatJar', () => {
+  const pp = lib.COMPONENTS['powpeg-node'];
+  const ctx = { semver: '9.0.0.0', codename: 'vetiver' };
+  assert.equal(pp.folder(ctx), 'VETIVER-9.0.0.0');
+  assert.deepEqual(pp.parseFolder('VETIVER-9.0.0.0'), { semver: '9.0.0.0', codename: 'vetiver' });
+  assert.deepEqual(pp.parseFolder('HOP-TESTNET-4.0.1.0'), { semver: '4.0.1.0', codename: 'hop-testnet' });
+  assert.equal(pp.fatJar(ctx), 'federate-node-VETIVER-9.0.0.0-all.jar');
+});
+
+// --- version substitution ---------------------------------------------------
+
+const RSKJ_DOCKERFILE = [
+  'RUN gitrev=VETIVER-9.0.2 && \\',
+  '    git checkout "$gitrev"',
+  'COPY --from=builder /root/.m2/repository/co/rsk/rskj-core/9.0.2-VETIVER/*.module ./',
+  'CMD ["java", "-cp", "rskj-core-9.0.2-VETIVER-all.jar", "co.rsk.Start"]',
+].join('\n');
+
+const RSKJ_README = [
+  '# rskj VETIVER-9.0.2',
+  '* Tag: `VETIVER-9.0.2`',
+  '$ docker build -t rskj/9.0.2-vetiver .',
+  '$ docker run --rm rskj/9.0.2-vetiver sh -c \'sha256sum * | grep -v javadoc.jar\'',
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  rskj-core-9.0.2-VETIVER-all.jar',
+  'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  rskj-core-9.0.2-VETIVER.jar',
+].join('\n');
+
+const POWPEG_README = [
+  '# powpeg-node VETIVER-9.0.0.0',
+  '$ docker run --rm powpeg-node/vetiver-9.0.0.0 bash -c \'sha256sum * | grep -v javadoc.jar\'',
+  'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  federate-node-VETIVER-9.0.0.0-all.jar',
+].join('\n');
+
+test('substituteVersion: rskj Dockerfile bumps every encoding, no stale version', () => {
+  const out = lib.substituteVersion(
+    RSKJ_DOCKERFILE,
+    { codename: 'vetiver', semver: '9.0.2' },
+    { codename: 'vetiver', semver: '9.0.3' },
+  );
+  assert.ok(out.includes('gitrev=VETIVER-9.0.3'));
+  assert.ok(out.includes('rskj-core/9.0.3-VETIVER/*.module'));
+  assert.ok(out.includes('rskj-core-9.0.3-VETIVER-all.jar'));
+  assert.ok(!out.includes('9.0.2'));
+});
+
+test('substituteVersion: rskj README title/tag/build-image bump', () => {
+  const out = lib.substituteVersion(
+    RSKJ_README,
+    { codename: 'vetiver', semver: '9.0.2' },
+    { codename: 'vetiver', semver: '9.0.3' },
+  );
+  assert.ok(out.includes('# rskj VETIVER-9.0.3'));
+  assert.ok(out.includes('Tag: `VETIVER-9.0.3`'));
+  assert.ok(out.includes('docker build -t rskj/9.0.3-vetiver .'));
+  assert.ok(!out.includes('9.0.2'));
+});
+
+test('substituteVersion: powpeg lowercased build-image form', () => {
+  const out = lib.substituteVersion(
+    POWPEG_README,
+    { codename: 'vetiver', semver: '9.0.0.0' },
+    { codename: 'vetiver', semver: '9.0.1.0' },
+  );
+  assert.ok(out.includes('# powpeg-node VETIVER-9.0.1.0'));
+  assert.ok(out.includes('powpeg-node/vetiver-9.0.1.0'));
+});
+
+// --- sha block handling -----------------------------------------------------
+
+test('injectShaBlock: replaces the hash run, leaves surrounding text', () => {
+  const fresh = ['1'.repeat(64) + '  rskj-core-9.0.3-VETIVER-all.jar'].join('\n');
+  const out = lib.injectShaBlock(RSKJ_README.replace(/9\.0\.2/g, '9.0.3'), fresh);
+  assert.equal((out.match(/^[0-9a-f]{64}\s/gm) || []).length, 1);
+  assert.ok(out.includes('1'.repeat(64)));
+  assert.ok(!out.includes('a'.repeat(64)));
+  assert.ok(out.includes('# rskj VETIVER-9.0.3')); // non-hash lines preserved
+});
+
+test('injectShaBlock: throws when no block present', () => {
+  assert.throws(() => lib.injectShaBlock('# no hashes here', 'x'), /no sha256 block/);
+});
+
+test('parseShaLine: finds a specific file', () => {
+  assert.equal(lib.parseShaLine(RSKJ_README, 'rskj-core-9.0.2-VETIVER.jar'), 'b'.repeat(64));
+  assert.equal(lib.parseShaLine(RSKJ_README, 'missing.jar'), null);
+});
+
+test('parseShaMap + mapsEqual', () => {
+  const m = lib.parseShaMap(RSKJ_README);
+  assert.equal(m.size, 2);
+  assert.equal(m.get('rskj-core-9.0.2-VETIVER-all.jar'), 'a'.repeat(64));
+  assert.ok(lib.mapsEqual(m, lib.parseShaMap(RSKJ_README)));
+  const diff = new Map(m);
+  diff.set('rskj-core-9.0.2-VETIVER-all.jar', '0'.repeat(64));
+  assert.ok(!lib.mapsEqual(m, diff));
+  const fewer = new Map(m);
+  fewer.delete('rskj-core-9.0.2-VETIVER.jar');
+  assert.ok(!lib.mapsEqual(m, fewer));
+});
+
+// --- misc helpers -----------------------------------------------------------
+
+test('componentShell: detects bash vs sh', () => {
+  assert.equal(lib.componentShell(POWPEG_README), 'bash');
+  assert.equal(lib.componentShell(RSKJ_README), 'sh');
+});
+
+test('hashFence: wraps in a code fence', () => {
+  assert.equal(lib.hashFence('H  x.jar'), '```\nH  x.jar\n```');
+});
+
+test('parsePrUrl: extracts owner/repo/number', () => {
+  assert.deepEqual(lib.parsePrUrl('https://github.com/rsksmart/reproducible-builds/pull/123'), {
+    owner: 'rsksmart',
+    repo: 'reproducible-builds',
+    number: '123',
+  });
+  assert.deepEqual(lib.parsePrUrl('https://github.com/o/r/pull/9/files'), { owner: 'o', repo: 'r', number: '9' });
+  assert.equal(lib.parsePrUrl('https://github.com/o/r/issues/9'), null);
+});
+
+test('detectBuildFromFiles: single build folder', () => {
+  const b = lib.detectBuildFromFiles(['rskj/9.0.3-vetiver/Dockerfile', 'rskj/9.0.3-vetiver/README.md', 'README.md']);
+  assert.equal(b.component.name, 'rskj');
+  assert.equal(b.folder, '9.0.3-vetiver');
+});
+test('detectBuildFromFiles: powpeg folder', () => {
+  const b = lib.detectBuildFromFiles(['powpeg-node/VETIVER-9.0.1.0/Dockerfile']);
+  assert.equal(b.component.name, 'powpeg-node');
+  assert.equal(b.folder, 'VETIVER-9.0.1.0');
+});
+test('detectBuildFromFiles: none -> null', () => {
+  assert.equal(lib.detectBuildFromFiles(['README.md', 'bitcoinj/x/Dockerfile']), null);
+});
+test('detectBuildFromFiles: multiple -> throws', () => {
+  assert.throws(
+    () => lib.detectBuildFromFiles(['rskj/9.0.3-vetiver/Dockerfile', 'rskj/8.1.0-reed/Dockerfile']),
+    /multiple build folders/,
+  );
+});


### PR DESCRIPTION
These changes are proposing a script to automatically create reproducible builds for rskj and/or powpeg-node using existing tags. This is done through a set of js scripts that allow to create the repro and allows others to validate them as well.

The script interacts with Github and Docker.