### PR TITLE
Adding reproducible build for VETIVER-9.0.3

### DIFF
--- a/rskj/9.0.3-vetiver/Dockerfile
+++ b/rskj/9.0.3-vetiver/Dockerfile
@@ -1,0 +1,34 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS builder
+
+RUN apt-get update -y && \
+    apt-get install -y -qq --no-install-recommends git curl gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code/rskj
+
+RUN gitrev=VETIVER-9.0.3 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test -x checkstyleMain -x checkstyleTest -x checkstyleIntegrationTest && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 AS runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/rskj-core-*.pom ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/9.0.3-VETIVER/*.module ./
+
+CMD ["java", "-cp", "rskj-core-9.0.3-VETIVER-all.jar", "co.rsk.Start"]

--- a/rskj/9.0.3-vetiver/README.md
+++ b/rskj/9.0.3-vetiver/README.md
@@ -1,0 +1,36 @@
+# rskj VETIVER-9.0.3
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `VETIVER-9.0.3`
+
+## Build
+
+```
+$ docker build -t rskj/9.0.3-vetiver .
+```
+
+## Verify
+
+Run the following command to verify the sha256sum of the built artifacts matches the expected values:
+
+```
+$ docker run --rm rskj/9.0.3-vetiver sh -c 'sha256sum * | grep -v javadoc.jar'
+b15fbccb9b1aa2cec082f6f68beeed23cbbcfcf1caf5d0099e4ad146e72b2135  rskj-core-9.0.3-VETIVER-all.jar
+d5d23756aae842a10b7e237cca3ad7900bfdaf71c469f24b5772742a96d584d5  rskj-core-9.0.3-VETIVER-sources.jar
+ad5c791752f328a3c6d272e924d67ba78939269e0e68b56f9987997fe8c80fb9  rskj-core-9.0.3-VETIVER.jar
+576c3964105a1e2e542596e6ddd8c66c06adca81420866cd89f9a455a074c5ac  rskj-core-9.0.3-VETIVER.module
+e71d4eed536cfeed21451086139d9c61cacd5de3ce61b3da7a13c94b5670f75f  rskj-core-9.0.3-VETIVER.pom
+```
+
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/9.0.3-vetiver
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/9.0.3-vetiver /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
Hashes:

```
b15fbccb9b1aa2cec082f6f68beeed23cbbcfcf1caf5d0099e4ad146e72b2135  rskj-core-9.0.3-VETIVER-all.jar
d5d23756aae842a10b7e237cca3ad7900bfdaf71c469f24b5772742a96d584d5  rskj-core-9.0.3-VETIVER-sources.jar
ad5c791752f328a3c6d272e924d67ba78939269e0e68b56f9987997fe8c80fb9  rskj-core-9.0.3-VETIVER.jar
576c3964105a1e2e542596e6ddd8c66c06adca81420866cd89f9a455a074c5ac  rskj-core-9.0.3-VETIVER.module
e71d4eed536cfeed21451086139d9c61cacd5de3ce61b3da7a13c94b5670f75f  rskj-core-9.0.3-VETIVER.pom
```