### PR TITLE
Adding reproducible build for VETIVER-9.0.4

### DIFF
--- a/rskj/9.0.4-vetiver/Dockerfile
+++ b/rskj/9.0.4-vetiver/Dockerfile
@@ -1,0 +1,34 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS builder
+
+RUN apt-get update -y && \
+    apt-get install -y -qq --no-install-recommends git curl gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code/rskj
+
+RUN gitrev=VETIVER-9.0.4 && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin "$gitrev" && \
+    git checkout FETCH_HEAD
+
+RUN curl -sSL https://secchannel.rsk.co/SUPPORT.asc | gpg --import && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test -x checkstyleMain -x checkstyleTest -x checkstyleIntegrationTest && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 AS runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/rskj-core-*.pom ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/9.0.4-VETIVER/*.module ./
+
+CMD ["java", "-cp", "rskj-core-9.0.4-VETIVER-all.jar", "co.rsk.Start"]

--- a/rskj/9.0.4-vetiver/README.md
+++ b/rskj/9.0.4-vetiver/README.md
@@ -1,0 +1,36 @@
+# rskj VETIVER-9.0.4
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `VETIVER-9.0.4`
+
+## Build
+
+```
+$ docker build -t rskj/9.0.4-vetiver .
+```
+
+## Verify
+
+Run the following command to verify the sha256sum of the built artifacts matches the expected values:
+
+```
+$ docker run --rm rskj/9.0.4-vetiver sh -c 'sha256sum * | grep -v javadoc.jar'
+79c2ea69c91092d6804dea75012d03e40057b11b1894783cd4923fd401f7c064  rskj-core-9.0.4-VETIVER-all.jar
+8ecbe77ec07665c666ad4c1b4dfc32d2642d4603475a6c99a4f17540f9f13367  rskj-core-9.0.4-VETIVER-sources.jar
+6190d64ee7cfcf66345b4bd8b70e7d64a97f24995b89952038a148d56998aa4a  rskj-core-9.0.4-VETIVER.jar
+7d7fb1870ce397e8a375ce375b31f9448d7af1444cb8899e8d2e6e16a510128c  rskj-core-9.0.4-VETIVER.module
+df341067d744cfb42e31be8b8301f8af608d83492bd7282b51af144e47152fce  rskj-core-9.0.4-VETIVER.pom
+```
+
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/9.0.4-vetiver
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/9.0.4-vetiver /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```


### PR DESCRIPTION
Hashes:

```
79c2ea69c91092d6804dea75012d03e40057b11b1894783cd4923fd401f7c064  rskj-core-9.0.4-VETIVER-all.jar
8ecbe77ec07665c666ad4c1b4dfc32d2642d4603475a6c99a4f17540f9f13367  rskj-core-9.0.4-VETIVER-sources.jar
6190d64ee7cfcf66345b4bd8b70e7d64a97f24995b89952038a148d56998aa4a  rskj-core-9.0.4-VETIVER.jar
7d7fb1870ce397e8a375ce375b31f9448d7af1444cb8899e8d2e6e16a510128c  rskj-core-9.0.4-VETIVER.module
df341067d744cfb42e31be8b8301f8af608d83492bd7282b51af144e47152fce  rskj-core-9.0.4-VETIVER.pom
```
